### PR TITLE
Commented out similar entry for "Boss - Vs. Character" (from Sonic '06)

### DIFF
--- a/Sonic The Hedgehog (2006)/metadata.yaml
+++ b/Sonic The Hedgehog (2006)/metadata.yaml
@@ -89,10 +89,10 @@ songs:
     title: "Boss - Egg-Cerebus & Egg Genesis"
     path: "Boss - Egg-Cerebus & Egg Genesis.brstm"
     type: battle
-  - id: boss_vs_character
-    title: "Boss - Vs. Character"
-    path: "Boss - Vs. Character.brstm"
-    type: battle
+#  - id: boss_vs_character
+#    title: "Boss - Vs. Character"
+#    path: "Boss - Vs. Character.brstm"
+#    type: battle
   - id: soleanna_castle_town
     title: "Soleanna Castle Town"
     path: "Soleanna Castle Town.brstm"


### PR DESCRIPTION
There are two similar entries (different game IDs for same metadata) for "Boss - Vs. Character.brstm", most recently they were played twice in a row (see https://youtu.be/cVa4xcRTpoU and https://youtu.be/rIqejY0zxd8).

I would highly recommend to delete either of the two entries to fix this.