### PR TITLE
Touhou fixes

### DIFF
--- a/Touhou Eiyashou_ Imperishable Night/metadata.yaml
+++ b/Touhou Eiyashou_ Imperishable Night/metadata.yaml
@@ -4,7 +4,7 @@ title: "Touhou Eiyashou ~ Imperishable Night"
 series: touhou
 platform: "PC"
 year: 2004
-songs: 
+songs:
   - id: eternal_night_vignette_eastern_night
     title: "Eternal Night Vignette ~ Eastern Night"
     path: "th08_01.txtp"
@@ -21,10 +21,10 @@ songs:
     title: "Song of the Night Sparrow ~ Night Bird"
     path: "th08_04.txtp"
     type: betting
-  - id: deaf_to_all_but_the_song
-    title: "Deaf to all but the song"
-    path: "th08_05.txtp"
-    type: battle
+#  - id: deaf_to_all_but_the_song
+#    title: "Deaf to all but the song"
+#    path: "th08_05.txtp"
+#    type: battle
   - id: nostalgic_blood_of_the_east_old_world
     title: "Nostalgic Blood of the East ~ Old World"
     path: "th08_06.txtp"

--- a/Touhou Kaeidzuka_ Phantasmagoria of Flower View/metadata.yaml
+++ b/Touhou Kaeidzuka_ Phantasmagoria of Flower View/metadata.yaml
@@ -4,7 +4,7 @@ title: "Touhou Kaeidzuka ~ Phantasmagoria of Flower View"
 series: touhou
 platform: "PC"
 year: 2005
-songs: 
+songs:
   - id: kaeidzuka_higan_retour
     title: "Kaeidzuka ~ Higan Retour"
     path: "th09_00.txtp"
@@ -16,26 +16,14 @@ songs:
   - id: oriental_dark_flight
     title: "Oriental Dark Flight"
     path: "th09_00b.txtp"
-    type: warning
+    type: betting
   - id: flowering_night
     title: "Flowering Night"
     path: "th09_02.txtp"
     type: battle
-  - id: mystic_oriental_dream_ancient_temple
-    title: "Mystic Oriental Dream ~ Ancient Temple"
-    path: "th07_10_b.txtp"
-    type: betting
-  - id: lunatic_eyes_invisible_full_moon
-    title: "Lunatic Eyes ~ Invisible Full Moon"
-    path: "th08_12.txtp"
-    type: betting
   - id: adventure_of_the_lovestruck_tomboy
     title: "Adventure of the Lovestruck Tomboy"
     path: "th09_05.txtp"
-    type: betting
-  - id: ghostly_band_phantom_ensemble
-    title: "Ghostly Band ~ Phantom Ensemble"
-    path: "th07_09.txtp"
     type: betting
   - id: deaf_to_all_but_the_song_flower_mix
     title: "Deaf to all but the song ~ Flower Mix"

--- a/Touhou Kanjuden_ Legacy of Lunatic Kingdom/metadata.yaml
+++ b/Touhou Kanjuden_ Legacy of Lunatic Kingdom/metadata.yaml
@@ -49,11 +49,11 @@ songs:
   - id: september_pumpkin
     title: "September Pumpkin"
     path: "Pumpkin of September.brstm"
-    type: warning
+    type: battle
   - id: the_mysterious_shrine_maiden_flying_through_space
     title: "The Mysterious Shrine Maiden Flying Through Space"
     path: "LoLKStage3ThemeTheMysteriousShrineMaidenFlyingThroughSpace.brstm"
-    type: battle
+    type: betting
   - id: pierrot_of_the_star_spangled_banner
     title: "Pierrot of the Star-Spangled Banner"
     path: "Pierrot of the Star Spangled Banner.brstm"

--- a/Touhou Kanjuden_ Legacy of Lunatic Kingdom/metadata.yaml
+++ b/Touhou Kanjuden_ Legacy of Lunatic Kingdom/metadata.yaml
@@ -14,7 +14,7 @@ songs:
     path: "LoLKStage2ThemeTheLakeReflectstheCleansedMoonlight.brstm"
     type: betting
   - id: frozen_capital_of_eternity
-    title: "Frozen Capital of Eternity"
+    title: "The Frozen Eternal Capital"
     path: "LoLKStage4ThemeFrozenCapitalofEternity.brstm"
     tags: [xmas]
     type: betting
@@ -67,7 +67,7 @@ songs:
     path: "Pandemonic Planet.brstm"
     type: battle
   - id: the_wheel_of_fortune_turning_over
-    title: "The Wheel of Fortune Turning Over"
+    title: "Reversed Wheel of Fortune"
     path: "The Reversed Wheel of Fortune.brstm"
     type: battle
 ...

--- a/Touhou Kishinjou_ Double Dealing Character/metadata.yaml
+++ b/Touhou Kishinjou_ Double Dealing Character/metadata.yaml
@@ -11,7 +11,7 @@ songs:
     type: betting
   - id: illusionary_joururi
     path: "Illusionary Shamisen Recital.brstm"
-    title: "Tsukumo Sisters' Theme: Illusionary Joururi"
+    title: "Illusionary Joururi"
     type: battle
   - id: the_antinomy_of_ideology_demetori
     title: "The Antinomy of Ideology (Arrange by Demetori)"
@@ -19,22 +19,22 @@ songs:
     type: battle
   - id: kobito_of_the_shining_needle_little_princess
     path: "Kobito of the Shining Needle ~ Little Princess.brstm"
-    title: "Shinmyoumaru's Theme: Kobito of the Shining Needle ~ Little Princess"
+    title: "Kobito of the Shining Needle ~ Little Princess"
     type: battle
   - id: four_children_arrange_of_little_princess
     path: "Four children.brstm"
     title: "~Four Children~ (Arrange of Little Princess by ルイージオ)"
     type: battle
   - id: kagerous_theme_lonesome_werewolf
-    title: "Kagerou's Theme: Lonesome Werewolf"
+    title: "Lonesome Werewolf"
     path: "Lonesome Werewolf.brstm"
     type: warning
   - id: seijas_theme_reverse_ideology
     path: "Reverse Ideology.brstm"
-    title: "Seija's Theme: Reverse Ideology"
+    title: "Reverse Ideology"
     type: battle
   - id: primordial_beat_pristine_beat
     path: "Primordial Beat ~ Pristine Beat.brstm"
-    title: "Raiko's Theme: Primordial Beat ~ Pristine Beat"
+    title: "Primordial Beat ~ Pristine Beat"
     type: battle
 ...

--- a/Touhou Kishinjou_ Double Dealing Character/metadata.yaml
+++ b/Touhou Kishinjou_ Double Dealing Character/metadata.yaml
@@ -4,7 +4,7 @@ title: "Touhou Kishinjou ~ Double Dealing Character"
 series: touhou
 platform: "PC"
 year: 2013
-songs: 
+songs:
   - id: touhou_kishinjou_shining_needle
     path: "The Shining Needle Castle that Sinks Through the Air.brstm"
     title: "The Shining Needle Castle that Sinks Through the Air"
@@ -36,5 +36,5 @@ songs:
   - id: primordial_beat_pristine_beat
     path: "Primordial Beat ~ Pristine Beat.brstm"
     title: "Raiko's Theme: Primordial Beat ~ Pristine Beat"
-    type: warning
+    type: battle
 ...

--- a/Touhou Shinreibyou_ Ten Desires/metadata.yaml
+++ b/Touhou Shinreibyou_ Ten Desires/metadata.yaml
@@ -41,7 +41,7 @@ songs:
   - id: legend_of_the_great_gods
     title: "Legend of the Great Gods"
     path: "Legend of the Great Gods.brstm"
-    type: warning
+    type: battle
   - id: youkai_back_shrine_road
     title: "Youkai Back Shrine Road"
     path: "Youkai Back Shrine Road.brstm"

--- a/Touhou Shinreibyou_ Ten Desires/metadata.yaml
+++ b/Touhou Shinreibyou_ Ten Desires/metadata.yaml
@@ -39,7 +39,7 @@ songs:
     path: "Ghost Lead.brstm"
     type: warning
   - id: legend_of_the_great_gods
-    title: "Legend of the Great Gods"
+    title: "Omiwa Legend"
     path: "Legend of the Great Gods.brstm"
     type: battle
   - id: youkai_back_shrine_road

--- a/Touhou Tenkuushou ~ Hidden Star in Four Seasons/metadata.yaml
+++ b/Touhou Tenkuushou ~ Hidden Star in Four Seasons/metadata.yaml
@@ -4,7 +4,7 @@ title: "Touhou Tenkuushou ~ Hidden Star in Four Seasons"
 series: touhou
 platform: "PC"
 year: 2017
-songs: 
+songs:
   - id: the_sky_where_cherry_blossoms_flutter_down
     title: "The Sky Where Cherry Blossoms Flutter Down"
     path: "01 The Sky Where Cherry Blossoms Flutter Down [Title Screen].genh"
@@ -40,7 +40,7 @@ songs:
   - id: the_magic_straw_hat_jizo
     title: "The Magic Straw-hat Jizo"
     path: "Touhou 16 OST - The Magic Straw-Hat Jizo.brstm"
-    type: betting
+    type: battle
   - id: does_the_forbidden_door_lead_to_this_world_or_the_world_beyond
     title: "Does the Forbidden Door Lead to This World, or the World Beyond"
     path: "Touhou 16 OST - Does the Forbidden Door Lead to This World, or To The Next.brstm"

--- a/Touhou Youyoumu_ Perfect Cherry Blossom/metadata.yaml
+++ b/Touhou Youyoumu_ Perfect Cherry Blossom/metadata.yaml
@@ -4,7 +4,7 @@ title: "Touhou Youyoumu ~ Perfect Cherry Blossom"
 series: touhou
 platform: "PC"
 year: 2003
-songs: 
+songs:
   - id: mystic_dream_snow_or_cherry_petal
     title: "Mystic Dream ~ Snow or Cherry Petal"
     path: "th07_01.txtp"
@@ -44,7 +44,7 @@ songs:
   - id: mystic_oriental_dream_ancient_temple
     title: "Mystic Oriental Dream ~ Ancient Temple"
     path: "th07_10.txtp"
-    type: battle
+    type: betting
   - id: hiroari_shoots_a_strange_bird_till_when
     title: "Hiroari Shoots a Strange Bird ~ Till When?"
     path: "th07_11.txtp"
@@ -64,7 +64,7 @@ songs:
   - id: charming_domination
     title: "Charming Domination"
     path: "th07_16.txtp"
-    type: battle
+    type: betting
   - id: a_msiden_s_illusionary_funeral_necro_fantasy
     title: "A Maiden's Illusionary Funeral ~ Necro-Fantasy"
     path: "th07_17.txtp"
@@ -84,7 +84,7 @@ songs:
   - id: sakura_sakura_japanize_dream
     title: "Sakura, Sakura ~ Japanize Dream..."
     path: "th07_15.txtp"
-    type: battle
+    type: result
   - id: bloom_nobly_ink_black_cherry_blossoms_arranged
     title: "Bloom Nobly, Ink-black Cherry Blossoms ~ Border of Life (Arranged)"
     path: "Bloom Nobly, Cherry Blossoms of Sumizone ~ Border of Life (Arranged).brstm"


### PR DESCRIPTION
- Touhou 9 has several songs reused from earlier games; those that were already in the song database have been removed. In the case of Mystia's theme, the Touhou 9 version was kept and the Touhou 8 version was commented out, because the former is an extended version.
- Boss themes which were in betting/warning were changed to battle as I saw fit
- Non-boss themes which were in battle were moved to other categories as I saw fit