### PR TITLE
TPP Music Update 80

### DIFF
--- a/Arzette The Jewel of Faramore/metadata.yaml
+++ b/Arzette The Jewel of Faramore/metadata.yaml
@@ -1,0 +1,135 @@
+---
+id: arzette_the_jewel_of_faramore
+title: "Arzette: The Jewel of Faramore"
+platform: "Various"
+year: 2024
+songs: 
+  - id: tutorial_arzette
+    title: "Tutorial"
+    path: "Tutorial.brstm"
+    type: betting
+  - id: world_map_arzette
+    title: "World Map"
+    path: "World Map.brstm"
+    type: betting
+  - id: bonus_arzette
+    title: "Bonus"
+    path: "Bonus.brstm"
+    type: warning
+  - id: boss_arzette
+    title: "Boss"
+    path: "Boss.brstm"
+    type: battle
+  - id: victory_arzette
+    title: "Victory"
+    path: "Victory.brstm"
+    type: result
+  - id: faramore_town
+    title: "Faramore Town"
+    path: "Faramore Town.brstm"
+    type: betting
+  - id: faramore_town_b_side
+    title: "Faramore Town (B-Side)"
+    path: "Faramore Town (B-Side).brstm"
+    type: betting
+  - id: durridin_forest
+    title: "Durridin Forest"
+    path: "Durridin Forest.brstm"
+    type: betting
+  - id: durridin_forest_b_side
+    title: "Durridin Forest (B-Side)"
+    path: "Durridin Forest (B-Side).brstm"
+    type: betting
+  - id: badonc_beach
+    title: "Badonc Beach"
+    path: "Badonc Beach .brstm"
+    type: betting
+  - id: badonc_beach_b_side
+    title: "Badonc Beach (B-Side)"
+    path: "Badonc Beach (B-Side).brstm"
+    type: betting
+  - id: anju_desert
+    title: "Anju Desert"
+    path: "Anju Desert.brstm"
+    type: betting
+  - id: anju_desert_b_side
+    title: "Anju Desert (B-Side)"
+    path: "Anju Desert (B-Side).brstm"
+    type: betting
+  - id: lichen_hills
+    title: "Lichen Hills"
+    path: "Lichen Hills .brstm"
+    type: break
+  - id: lichen_hills_b_side
+    title: "Lichen Hills (B-Side)"
+    path: "Lichen Hills (B-Side).brstm"
+    type: break
+  - id: norin_swap
+    title: "Norin Swamp"
+    path: "Norin Swamp .brstm"
+    type: break
+  - id: norin_swamp_b_side
+    title: "Norin Swamp (B-Side)"
+    path: "Norin Swamp (B-Side).brstm"
+    type: betting
+  - id: ryha_river
+    title: "Ryha River"
+    path: "Ryha River.brstm"
+    type: betting
+  - id: ryha_river_b_side
+    title: "Ryha River (B-Side)"
+    path: "Ryha River (B-Side).brstm"
+    type: break
+  - id: boanjale_crypts
+    title: "Boanjale Crypts"
+    path: "Boanjale Crypts.brstm"
+    type: betting
+  - id: boanjale_crypts_b_side
+    title: "Boanjale Crypts (B-Side)"
+    path: "Boanjale Crypts (B-Side).brstm"
+    type: betting
+  - id: chillinax_peaks
+    title: "Chillinax Peaks"
+    path: "Chillinax Peaks.brstm"
+    type: betting
+  - id: chillinax_peaks_b_side
+    title: "Chillinax Peaks (B-Side)"
+    path: "Chillinax Peaks (B-Side).brstm"
+    type: break
+  - id: fort_findula
+    title: "Fort Findula"
+    path: "Fort Findula .brstm"
+    type: betting
+  - id: fort_findula_b_side
+    title: "Fort Findula (B-Side)"
+    path: "Fort Findula (B-Side).brstm"
+    type: betting
+  - id: denny_s_castle
+    title: "Denny's Castle"
+    path: "Denny's Castl.brstm"
+    type: betting
+  - id: denny_s_castle_b_side
+    title: "Denny's Castle (B-Side)"
+    path: "Denny's Castle (B-Side).brstm"
+    type: betting
+  - id: sprigum_volcano
+    title: "Sprigum Volcano"
+    path: "Sprigum Volcano.brstm"
+    type: betting
+  - id: cogwyn_caves
+    title: "Cogwyn Caves"
+    path: "Cogwyn Caves.brstm"
+    type: betting
+  - id: creece_canyon
+    title: "Creece Canyon"
+    path: "Creece Canyon.brstm"
+    type: betting
+  - id: daimur_s_lair
+    title: "Daimur's Lair"
+    path: "Daimur's Lair.brstm"
+    type: betting
+  - id: final_boss_arzette
+    title: "Final Boss"
+    path: "Final Boss.brstm"
+    type: battle
+...

--- a/Astro Bot/metadata.yaml
+++ b/Astro Bot/metadata.yaml
@@ -108,4 +108,12 @@ songs:
     title: "Goal (ASTRO BOT Remix)"
     path: "Goal (ASTRO BOT Remix).brstm"
     type: result
+  - id: i_am_astro_bot_astro_bot_remix
+    title: "I Am Astro Bot (ASTRO BOT Remix)"
+    path: "I Am Astro Bot (ASTRO BOT Remix).brstm"
+    type: betting
+  - id: the_satellite_astro_bot
+    title: "The Satellite"
+    path: "The Satellite.brstm"
+    type: warning
 ...

--- a/B3313/metadata.yaml
+++ b/B3313/metadata.yaml
@@ -1,0 +1,69 @@
+---
+id: b3313
+title: "B3313"
+platform: "N64"
+series: mario
+is_fanwork: true 
+year: 2024
+songs:
+  - id: bob_omb_village
+    title: "Bob-Omb Village"
+    path: "Bob-Omb Village.brstm"
+    type: betting
+  - id: downtown_city_b3313
+    title: "Downtown City"
+    path: "Downtown City.brstm"
+    type: betting
+  - id: snow_mountain_unused_version
+    title: "Snow Mountain (Unused Version)"
+    path: "Snow Mountain (Unused Version).brstm"
+    type: betting
+  - id: chain_chomp_cliffs
+    title: "Chain Chomp Cliffs"
+    path: "Chain Chomp Cliffs.brstm"
+    type: betting
+  - id: wet_or_dry
+    title: "Wet or Dry"
+    path: "Wet or Dry.brstm"
+    type: betting
+  - id: descending_stairs
+    title: "Descending Stairs"
+    path: "Descending Stairs.brstm"
+    type: warning
+  - id: rose_tinted_purgatory
+    title: "Rose-Tinted Purgatory"
+    path: "Rose-Tinted Purgatory.brstm"
+    type: warning
+  - id: throne_room_b3313
+    title: "Throne Room"
+    path: "Throne Room.brstm"
+    type: warning
+  - id: wf_z64
+    title: "wf.z64"
+    path: "wf.z64.brstm"
+    type: break
+  - id: running_about_b3313
+    title: "Running About"
+    path: "Running About.brstm"
+    type: betting
+  - id: underground_beta
+    title: "Underground (Beta)"
+    path: "Underground (Beta).brstm"
+    type: betting
+  - id: secret_of_the_plexus
+    title: "Secret of the Plexus"
+    path: "Secret of the Plexus.brstm"
+    type: betting
+  - id: polygonal_chaos
+    title: "Polygonal Chaos"
+    path: "Polygonal Chaos.brstm"
+    type: warning
+  - id: nebula_castle_lobby
+    title: "Nebula Castle Lobby"
+    path: "Nebula Castle Lobby.brstm"
+    type: betting
+  - id: eel_graveyard
+    title: "Eel Graveyard"
+    path: "Eel Graveyard.brstm"
+    type: break
+...

--- a/Balatro/metadata.yaml
+++ b/Balatro/metadata.yaml
@@ -6,6 +6,22 @@ year: 2024
 songs: 
   - id: main_theme_balatro
     title: "Main Theme"
-    path: "music1.ogg" #dunno why it's sped up
+    path: "music1_main.txtp"
+    type: betting
+  - id: arcana_pack
+    title: "Arcana Pack"
+    path: "music2_arcana.txtp"
+    type: betting
+  - id: celestial_pack
+    title: "Celestial Pack"
+    path: "music3_celestial.txtp"
+    type: betting
+  - id: shop_balatro
+    title: "Shop"
+    path: "music4_shop.txtp"
+    type: betting
+  - id: boss_blind
+    title: "Boss Blind"
+    path: "music5_boss.txtp"
     type: betting
 ...

--- a/Bio Metal/metadata.yaml
+++ b/Bio Metal/metadata.yaml
@@ -8,4 +8,60 @@ songs:
     title: "Bio Metal Warfare"
     path: "101 Bio Metal Warfare.spc"
     type: betting
+  - id: preparations_biometal
+    title: "Preparations"
+    path: "103 Preparations.spc"
+    type: betting
+  - id: dark_clouds
+    title: "Dark Clouds"
+    path: "104 Dark Clouds.spc"
+    type: betting
+  - id: boss_encounter_biometal
+    title: "Boss Encounter"
+    path: "105 Boss Encounter.spc"
+    type: warning
+  - id: desert_storm_biometal
+    title: "Desert Storm"
+    path: "107 Desert Storm.spc"
+    type: betting
+  - id: major_battle_biometal
+    title: "Major Battle"
+    path: "108 Major Battle.spc"
+    type: warning
+  - id: steel_skeleton
+    title: "Steel Skeleton"
+    path: "111 Steel Skeleton.spc"
+    type: warning
+  - id: core_of_the_bio_metal_planet
+    title: "Core of the Bio Metal Planet"
+    path: "114 Core of the Bio Metal Planet.spc"
+    type: warning
+  - id: can_t_give_up
+    title: "Can't Give Up..."
+    path: "116 Can't Give Up....spc"
+    type: result
+  - id: dark_clouds_us_ver
+    title: "Dark Clouds (US Ver)"
+    path: "201 Dark Clouds.spc"
+    type: betting
+  - id: desert_storm_us_ver
+    title: "Desert Storm (US Ver)"
+    path: "202 Desert Storm.spc"
+    type: betting
+  - id: metal_insect_lair_us_ver
+    title: "Metal Insect Lair (US Ver)"
+    path: "203 Metal Insect Lair.spc"
+    type: betting
+  - id: deep_underground_ruins_us_ver
+    title: "Deep Underground Ruins (US Ver)"
+    path: "204 Deep Underground Ruins.spc"
+    type: betting
+  - id: steel_skeleton_us_ver
+    title: "Steel Skeleton (US Ver)"
+    path: "205 Steel Skeleton.spc"
+    type: warning
+  - id: last_assault_us_bio_metal
+    title: "Last Assault (US Ver)"
+    path: "206 Last Assault.spc"
+    type: battle
 ...

--- a/Cognitive Dissonance/metadata.yaml
+++ b/Cognitive Dissonance/metadata.yaml
@@ -1,0 +1,80 @@
+---
+id: cognitive_dissonance_a_ccc_side_story
+title: "Cognitive Dissonance: A CCC Side Story"
+platform: "PC"
+series: siivagunner
+year: 2024
+songs:
+  - id: laborator
+    title: "Laborator"
+    path: "laborator.txtp"
+    type: break
+  - id: chimera_research
+    title: "Chimera Research"
+    path: "chimera.txtp"
+    type: warning
+  - id: mr_dee
+    title: "Mr. Dee"
+    path: "synchronicity.txtp"
+    type: betting
+  - id: see_you_next_tuesday
+    title: "See You Next Tuesday"
+    path: "tuesday.txtp"
+    type: battle
+  - id: anguish_avenue
+    title: "Anguish Avenue"
+    path: "anguish.txtp"
+    type: warning
+  - id: game_over_ccc
+    title: "Game Over"
+    path: "gameover.ogg"
+    type: result
+  - id: battle_against_a_perfect_being
+    title: "BATTLE AGAINST A PERFECT BEING"
+    path: "guilt2.txtp"
+    type: battle
+  - id: uncomfortable_elevator
+    title: "Uncomfortable Elevator"
+    path: "elevatorloop.txtp"
+    type: warning
+  - id: eternal_echo_of_the_thrilling_joke_oke_oke
+    title: "Eternal Echo of the Thrilling Joke-oke-oke"
+    path: "FuckedUpAudio.ogg"
+    type: warning
+  - id: sea_of_the_monster_s_elevator
+    title: "Sea of the Monster's Elevator"
+    path: "flooding.ogg"
+    type: warning
+  - id: atop_the_tower_ccc
+    title: "Atop the Tower"
+    path: "loveless.ogg"
+    type: warning
+  - id: the_sickness_unto
+    title: "the sickness unto"
+    path: "guilt3.txtp"
+    type: warning
+  - id: chill_and_rigor_cogdis_mix
+    title: "Chill and Rigor (CogDis Mix)"
+    path: "chillrig.txtp"
+    type: break
+  - id: clocking_in_ccc
+    title: "Clocking In"
+    path: "Clocking In.ogg"
+    type: warning
+  - id: donut_break
+    title: "Donut Break"
+    path: "Donut Break.txtp"
+    type: battle
+  - id: donut_holes
+    title: "Donut Holes"
+    path: "donuthole.txtp"
+    type: warning
+  - id: the_hero_returns_ccc
+    title: "The Hero Returns"
+    path: "heroesreturn.ogg"
+    type: break
+  - id: magicant_ccc
+    title: "Magicant"
+    path: "magicant.txtp"
+    type: break
+...

--- a/FNF SHITTLY/metadata.yaml
+++ b/FNF SHITTLY/metadata.yaml
@@ -1,0 +1,12 @@
+---
+id: fnf_shittly
+title: "FNF SHITTLY"
+platform: "PC"
+year: 2024
+is_fanwork: true
+songs: 
+  - id: wacky_game_songz_for_kidz_instrumental
+    title: "Wacky Game Songz For Kidz! (Instrumental)"
+    path: "Wacky Game Songz For Kidz! (Instrumental).brstm"
+    type: warning
+...

--- a/Furi/metadata.yaml
+++ b/Furi/metadata.yaml
@@ -1,0 +1,23 @@
+---
+id: furi
+title: "Furi"
+platform: "Various"
+year: 2016
+songs: 
+  - id: a_monster_furi
+    title: "A Monster"
+    path: "A Monster.brstm"
+    type: betting
+  - id: a_picture_in_motion
+    title: "A Picture in Motion"
+    path: "A Picture in Motion.brstm"
+    type: betting
+  - id: you_are_the_end
+    title: "You Are the End"
+    path: "You Are the End.brstm"
+    type: betting
+  - id: you_re_mine
+    title: "You're Mine"
+    path: "You're Mine.brstm"
+    type: battle
+...

--- a/House M.D/metadata.yaml
+++ b/House M.D/metadata.yaml
@@ -1,0 +1,15 @@
+---
+id: house_md
+title: "House M.D."
+platform: "PC"
+year: 2010
+songs: 
+  - id: mission_house
+    title: "Mission"
+    path: "Mission.brstm"
+    type: warning
+  - id: maze_game_house
+    title: "Maze Game"
+    path: "Maze Game.brstm"
+    type: betting
+...

--- a/Kindergarten Wars/metadata.yaml
+++ b/Kindergarten Wars/metadata.yaml
@@ -1,0 +1,11 @@
+---
+id: kindergarten_wars_yochien_kyoyu_no_zukkyun_na_otomege
+title: "Kindergarten Wars: Yōchien Kyōyu No Zukkyun Na Otomegē"
+platform: "Web"
+year: 2025
+songs: 
+  - id: main_game_kw
+    title: "Main Game"
+    path: "KW OTOME 04. Main Game.mp3"
+    type: result
+...

--- a/Kirby Star Allies/metadata.yaml
+++ b/Kirby Star Allies/metadata.yaml
@@ -17,8 +17,8 @@ songs:
     title: "Honey Hill"
     path: "iukMori.dspadpcm.bfstm"
     type: betting
-  - id: for_those_who_are_brave
-    title: "For Those Who Are Brave"
+  - id: for_the_brave
+    title: "For the Brave"
     path: "d3castle.dspadpcm.bfstm"
     type: betting
   - id: friendly_field
@@ -41,52 +41,52 @@ songs:
     title: "Sacred Square"
     path: "ECL_LP_ECYUUHI1.dspadpcm.bfstm"
     type: betting
-  - id: to_the_land_where_grass_doesn_t_grow
-    title: "To the Land Where Grass Doesn't Grow"
+  - id: where_even_weeds_won_t_grow
+    title: "Where Even Weeds Won't Grow"
     path: "BossMid.dspadpcm.bfstm"
     type: betting
-  - id: jambastion_adventure
-    title: "Jambastion Adventure"
+  - id: adventures_in_jambastion
+    title: "Adventures in Jambastion"
     path: "yousai.dspadpcm.bfstm"
     type: betting
-  - id: i_believe_in_my_friends
-    title: "I Believe in My Friends"
+  - id: true_friends_stand_with_you
+    title: "True Friends Stand with You"
     path: "yousai2.dspadpcm.bfstm"
     type: betting
-  - id: puzzle_galaxy
-    title: "Puzzle Galaxy"
+  - id: puzzle_solving_galaxy
+    title: "Puzzle-Solving Galaxy"
     path: "fami_kkt.dspadpcm.bfstm"
     type: betting
-  - id: wind_blowing_on_earthfall
-    title: "Wind Blowing on Earthfall"
+  - id: winds_across_earthfall
+    title: "Winds across Earthfall"
     path: "BGM_LP_ECMORI2.dspadpcm.bfstm"
     type: betting
-  - id: misteen_ocean
-    title: "Misteen Ocean"
+  - id: misteen_s_oceans
+    title: "Misteen's Oceans"
     path: "ECL_LP_ECBEACHK3.dspadpcm.bfstm"
     type: betting
-  - id: caverna_great_labyrinth
-    title: "Caverna Great Labyrinth"
+  - id: caverna_s_massive_mazes
+    title: "Caverna's Massive Mazes"
     path: "tower.dspadpcm.bfstm"
     type: betting
-  - id: frostak_cold_area
-    title: "Frostak Cold Area"
+  - id: frostak_s_arctic_tundra
+    title: "Frostak's Arctic Tundra"
     path: "RRes.dspadpcm.bfstm"
     type: betting
-  - id: ancient_tower_towara
-    title: "Ancient Tower Towara"
+  - id: towara_s_ancient_towers
+    title: "Towara's Ancient Towers"
     path: "ECL_LP_ECTOU1.dspadpcm.bfstm"
     type: betting
-  - id: new_star_lavadom
-    title: "New Star Lavadom"
+  - id: star_lavadom
+    title: "Star Lavadom"
     path: "ECL_LP_ECFIRESTEP1.dspadpcm.bfstm"
     type: betting
-  - id: land_of_dreams_and_greenery_s_remains
-    title: "Land of Dreams and Greenery's Remains"
+  - id: scarred_lands_of_dreams_and_new_greens
+    title: "Scarred Lands of Dreams and New Greens"
     path: "lastGreens.dspadpcm.bfstm"
     type: betting
-  - id: select_screen_kirby_star_allies
-    title: "Select Screen"
+  - id: select_file_kirby_star_allies
+    title: "Select File"
     path: "title_pf.dspadpcm.bfstm"
     type: break
   - id: world_of_peace_dream_land
@@ -97,16 +97,16 @@ songs:
     title: "Far-Flung Starlight Heroes"
     path: "BGM_LP_ECMAP4.bfstm"
     type: betting
-  - id: memorial_festival
-    title: "Memorial Festival"
+  - id: the_palace_of_fulfilled_Dreams
+    title: "The Palace of Fulfilled Dreams"
     path: "pf_kakuto.dspadpcm.bfstm"
     type: betting
-  - id: twinkle_traveler
-    title: "Twinkle ☆ Traveler"
+  - id: twinkling_travelers
+    title: "Twinkling☆Travelers"
     path: "star.dspadpcm.bfstm"
     type: warning
-  - id: illustration_results
-    title: "Illustration Results"
+  - id: picture_results
+    title: "Picture Results"
     path: "lololo.dspadpcm.bfstm"
     type: result
   - id: sudden_happy_ending
@@ -117,21 +117,21 @@ songs:
     title: "Star Slam Heroes"
     path: "BGM_LP_ECSUBHOMERUN.dspadpcm.bfstm"
     type: warning
-  - id: always_i_ll_be_watching_you
-    title: "Always, I'll Be Watching You."
+  - id: having_watched_you_all_along
+    title: "Having Watched You All Along"
     path: "sroll.dspadpcm.bfstm"
     ends: 3:38
     type: betting
-  - id: choosing_the_ultimate_choice_s_flavour
-    title: "Choosing the Ultimate Choice's Flavor"
+  - id: your_preferred_spiciness_for_the_ultimate_choice
+    title: "Your Preferred Spiciness for the Ultimate Choice"
     path: "BGM_LP_ECKAKUTO1.dspadpcm.bfstm"
     type: betting
-  - id: venturing_into_the_world_with_friends
-    title: "Venturing Into the World With Friends"
+  - id: venturing_into_the_world_with_allies
+    title: "Venturing Into the World With Allies"
     path: "pf_torteStg.dspadpcm.bfstm"
     type: result
-  - id: best_friends_tomorrow_and_always
-    title: "Best Friends, Tomorrow and Always"
+  - id: best_friends_today_tomorrow_and_always
+    title: "Best Friends, Today, Tomorrow, and Forever"
     path: "staff_medley.dspadpcm.bfstm"
     ends: 3:40
     type: betting
@@ -143,28 +143,28 @@ songs:
     title: "Macho of Dedede"
     path: "ddd.dspadpcm.bfstm"
     type: battle
-  - id: friends_and_the_sound_of_those_crossing_blades
-    title: "Friends and the Sound of Those Crossing Blades"
+  - id: the_clash_of_comrades_blades
+    title: "The Clash of Comrades' Blades"
     path: "ECL_LP_ECMETABOSS1.dspadpcm.bfstm"
     type: betting
   - id: song_of_supplication
     title: "Song of Supplication"
     path: "EP3BOSS.dspadpcm.bfstm"
     type: betting
-  - id: forgotten_flash_of_lightning
-    title: "Forgotten Flash of Lightning"
+  - id: a_forgotten_flash_of_lightning
+    title: "A Forgotten Flash of Lightning"
     path: "sanmaHead.dspadpcm.bfstm"
     type: battle
   - id: la_follia_d_amore
     title: "La Follia d'amore"
     path: "ECL_LP_BOSSLAST2.dspadpcm.bfstm"
     type: battle
-  - id: fourth_movement_the_birth_of_hope
-    title: "Fourth Movement: The Birth of Hope"
+  - id: movement_4_the_birth_of_hope
+    title: "Movement 4: The Birth of Hope"
     path: "LastBoass4.dspadpcm.bfstm"
     type: battle
-  - id: all_those_star_friends_they_re_with_me
-    title: "All Those Star Friends, They're With Me!"
+  - id: the_star_allies_have_your_back
+    title: "The Star Allies Have Your Back!"
     path: "akarui4.dspadpcm.bfstm"
     type: battle
   - id: butterfly_of_judgement_morpho_knight
@@ -172,23 +172,23 @@ songs:
     path: "B_Night.dspadpcm.bfstm"
     type: battle
   - id: dark_cloudy
-    title: "Dark Cloudy"
+    title: "Dark & Cloudy"
     path: "Kirby2_Boss.dspadpcm.bfstm"
     type: battle
   - id: vs_marx_star_allies
-    title: "Vs. Marx / Star Allies Dream ver."
+    title: "Vs. Marx — Star Allies Dream ver."
     path: "BGM_LP_ECDLBOSSMARK1.dspadpcm.bfstm"
     type: battle
   - id: dark_matter_in_the_hyper_zone
     title: "Dark Matter in the Hyper Zone"
     path: "Kirby3_Boss.dspadpcm.bfstm"
     type: battle
-  - id: third_movement_the_wings_of_sorrow_and_great_heavens
-    title: "Third Movement: The Wings of Sorrow and Great Heavens"
+  - id: movement_3_wings_of_sorrow_and_the_heavens
+    title: "Movement 3: Wings of Sorrow and the Heavens"
     path: "Last3rg.dspadpcm.bfstm"
     type: betting
-  - id: second_movement_the_embryo_s_vessel
-    title: "Second Movement: The Embryo's Vessel"
+  - id: movement_2_vessel_of_the_embryo
+    title: "Movement 2: Vessel of the Embryo"
     path: "Last2rg1201.dspadpcm.bfstm"
     type: betting
   - id: friends_getaway_ksa
@@ -203,12 +203,12 @@ songs:
     title: "Shadowy Partners"
     path: "BGM_LP_ECDLDMETADOROCHE1.dspadpcm.bfstm"
     type: betting
-  - id: the_girls_battle_with_darkness
-    title: "The Girls' Battle with Darkness"
+  - id: the_girls_who_fought_the_darkness
+    title: "The Girls Who Fought the Darkness"
     path: "K64Boss.dspadpcm.bfstm"
     type: battle
-  - id: true_theme_of_the_squeaks
-    title: "True! Theme of the Squeaks"
+  - id: true_squeak_squad_theme
+    title: "True Squeak Squad Theme"
     path: "BGM_LP_ECDLDOROCHE1.dspadpcm.bfstm"
     type: battle
   - id: dark_mirage_kirby_star_allies
@@ -219,57 +219,57 @@ songs:
     title: "Heroes in Another Dimension"
     path: "BGM_LP_ECDLANOTHERTITLE1.dspadpcm.bfstm"
     type: betting
-  - id: the_legend_of_last_world
-    title: "The Legend of Last World"
+  - id: the_legend_of_the_last_world
+    title: "The Legend of the Last World"
     path: "LastStageMed.dspadpcm.bfstm"
     type: betting
-  - id: battle_with_another_world_s_sword_king
-    title: "Battle With Another World's Sword King"
+  - id: against_a_sword_king_the_dimension_to_win
+    title: "Against a Sword-King, the Dimension to Win"
     path: "BGM_LP_ECDLANOTHERBOSS2.dspadpcm.bfstm"
     type: battle
-  - id: passion_of_the_tridental_flashing_priestesses
-    title: "Passion of the Tridental-Flashing Priestesses"
+  - id: oracles_of_the_threefold_glint
+    title: "Oracles of the Threefold Glint"
     path: "SanmaBoss.dspadpcm.bfstm"
     type: battle
-  - id: memories_of_the_finale
-    title: "Memories, of the Finale"
+  - id: memories_of_the_grande_finale
+    title: "Memories of the Grande Finale"
     path: "EndMed.dspadpcm.bfstm"
     ends: 3:46
     type: betting
-  - id: hallway_to_the_origin
-    title: "Hallway to the Origin"
+  - id: aeon_corridors
+    title: "Aeon Corridors"
     path: "WiiBossMae.dspadpcm.bfstm"
     type: warning
-  - id: final_movement_sparkling_star
-    title: "Final Movement: Sparkling Star"
+  - id: closing_movement__the_twinkling_star
+    title: "Closing Movement: The Twinkling Star"
     path: "LastBoss2nd.dspadpcm.bfstm"
     type: battle
-  - id: with_four_friends_cookie_country_star_allies_arrange_ver
-    title: "With Four Friends: Cookie Country / Star Allies Arrange ver."
+  - id: four_adventurers_cookie_country_star_allies_arrangement
+    title: "Four Adventurers: Cookie Country — Star Allies Arrangement"
     path: "BGM_LP_ECDLMAGOLORCOOKIE1.dspadpcm.bfstm"
     type: betting
-  - id: taranza_the_master_of_puppetry_star_allies_arrange_ver
-    title: "Taranza, the Master of Puppetry / Star Allies Arrange ver."
+  - id: taranza_puppeteer_magician_star_allies_arrangement
+    title: "Taranza the Puppeteer Magician — Star Allies Arrangement"
     path: "BGM_LP_ECDLTARANZA1.dspadpcm.bfstm"
     type: betting
-  - id: the_noble_haltmann_star_allies_arrange_ver
-    title: "The Noble Haltmann / Star Allies Arrange ver."
+  - id: the_noble_haltmann_star_allies_arrangement
+    title: "The Noble Haltmann — Star Allies Arrangement"
     path: "BGM_LP_ECDLSUSIEROOM1.dspadpcm.bfstm"
     type: warning
-  - id: nightmare_battle
-    title: "Nightmare Battle"
+  - id: battle_of_nightmares
+    title: "Battle of Nightmares"
     path: "BGM_LP_ECDLIZUMINIGHTMARE1.dspadpcm.bfstm"
     type: battle
   - id: supreme_ruler_s_coronation_overlord
     title: "Supreme Ruler's Coronation - OVERLORD"
     path: "crowned_2018_0906a.dspadpcm.bfstm"
     type: battle
-  - id: phantom_of_the_moon
-    title: "Phantom of the Moon"
+  - id: phantom_of_the_moon_soul
+    title: "Phantom of the Moon Soul"
     path: "Taranza.dspadpcm.bfstm"
     type: battle
-  - id: deus_ex_machina_seen_in_childhood
-    title: "Deus · Ex · Machina Seen in Childhood"
+  - id: a_deus_ex_machina_from_childhood
+    title: "A Deus Ex Machina from Childhood"
     path: "RBBBoss.dspadpcm.bfstm"
     type: battle
   - id: the_shape_of_a_heart
@@ -288,8 +288,8 @@ songs:
     title: "Let Them Know We're Happy"
     path: "BGM_LP_ECDLSANMAKAN1.dspadpcm.bfstm"
     type: break
-  - id: a_farewell_to_kirby
-    title: "A Farewell to Kirby"
+  - id: a_farewell_to_kirby_he_of_the_future_traveling_stars
+    title: "A Farewell to Kirby: He of the Future-Traveling Stars"
     path: "BGM_LP_ECDLTITLE1.dspadpcm.bfstm"
     type: break
 ...

--- a/Kirby's Blowout Blast/metadata.yaml
+++ b/Kirby's Blowout Blast/metadata.yaml
@@ -17,8 +17,8 @@ songs:
     title: "Bubbly Clouds"
     path: "GB_Bubbly.dspadpcm.bcstm"
     type: betting
-  - id: entrance_kirbys_blowout_blast
-    title: "Entrance"
+  - id: plaza_kirbys_blowout_blast
+    title: "Plaza"
     path: "GB_QKJyo.dspadpcm.bcstm"
     type: warning
   - id: boss_theme_kirbys_blowout_blast
@@ -37,32 +37,32 @@ songs:
     title: "Ending"
     path: "GB_StaffRoll.dspadpcm.bcstm"
     type: result
-  - id: king_dedede_s_theme_amiibo_special_ver
-    title: "King Dedede's Theme / amiibo Special ver."
+  - id: king_dedede_s_theme_amiibo_special_arrangement
+    title: "King Dedede's Theme — amiibo Special Arrangement"
     path: "dddnddd.dspadpcm.bcstm"
     type: result
   - id: king_dededes_theme_kirbys_blowout_blast
     title: "King Dedede's Theme"
     path: "GBDDD_Long.dspadpcm.bcstm"
     type: battle
-  - id: the_adventure_begins_amiibo_special_ver
-    title: "The Adventure Begins / amiibo Special ver."
+  - id: the_adventure_begins_amiibo_special_arrangement
+    title: "The Adventure Begins — amiibo Special Arrangement"
     path: "amiiboKirbyWii.dspadpcm.bcstm"
     type: betting
-  - id: meta_knights_revenge_amiibo_special_ver
-    title: "Meta Knight's Revenge / amiibo Special ver."
+  - id: meta_knights_revenge_amiibo_special_arrangement
+    title: "Meta Knight's Revenge — amiibo Special Arrangement"
     path: "amiiboMeta.dspadpcm.bcstm"
     type: betting
   - id: mid_boss_kirbys_blowout_blast
     title: "Mid-Boss"
     path: "FC_Tamago.dspadpcm.bcstm"
     type: warning
-  - id: tommorrow_is_tommorows_great_battle
-    title: "Tommorow is Tommorow's Great Battle"
+  - id: a_decisive_battle_for_tomorrow_blowout_blast
+    title: "A Decisive Battle for Tomorrow"
     path: "EndLastBoss.dspadpcm.bcstm"
     type: betting
   - id: floral_fields_amiibo_special_ver
-    title: "Floral Fields / amiibo Special ver."
+    title: "Floral Fields — amiibo Special Arrangement"
     path: "amiiboWado.dspadpcm.bcstm"
     type: betting
 ...

--- a/Knuckle Sandwich/metadata.yaml
+++ b/Knuckle Sandwich/metadata.yaml
@@ -1,0 +1,35 @@
+---
+id: knuckle_sandwich
+title: "Knuckle Sandwich"
+platform: "PC"
+year: 2023
+songs: 
+  - id: biggest_punch
+    title: "Biggest Punch"
+    path: "Biggest Punch.brstm"
+    type: warning
+  - id: thieving_snoop
+    title: "Thieving Snoop"
+    path: "Thieving Snoop.brstm"
+    type: betting
+  - id: side_street_step
+    title: "Side Street Step"
+    path: "Side Street Step.brstm"
+    type: betting
+  - id: handsome_humanoids
+    title: "Handsome Humanoids"
+    path: "Handsome Humanoids.brstm"
+    type: result
+  - id: go_go_power_muscle
+    title: "Go! Go! Power Muscle"
+    path: "Go! Go! Power Muscle.brstm"
+    type: battle
+  - id: the_final_boss_knuckle_sandwich
+    title: "The Final Boss"
+    path: "The Final Boss.brstm"
+    type: betting
+  - id: end_credits_knuckle_sandwich
+    title: "End Credits"
+    path: "End Credits (Custom loop).brstm"
+    type: result
+...

--- a/Kolo Terorita/metadata.yaml
+++ b/Kolo Terorita/metadata.yaml
@@ -2,6 +2,7 @@
 id: kolo_terorita
 title: "Kolo Terorita"
 platform: "PC"
+series: siivagunner
 year: 2022
 songs:
   - id: never_stop_shaking

--- a/LazyTown Festival/metadata.yaml
+++ b/LazyTown Festival/metadata.yaml
@@ -1,0 +1,12 @@
+---
+id: lazytown_festival
+title: "LazyTown: Festival"
+platform: "PC"
+year: 2009
+songs: 
+  - id: order_in_square
+    title: "Order in Square"
+    path: "02. Order in Square.mp3"
+    ends: 2:18
+    type: betting
+...

--- a/Loomian Legacy/metadata.yaml
+++ b/Loomian Legacy/metadata.yaml
@@ -41,4 +41,36 @@ songs:
     title: "Smoldering Heat Weather Theme"
     path: "Smoldering Heat Weather Theme.brstm"
     type: betting
+  - id: ranked_battle_selection
+    title: "Ranked Battle Selection"
+    path: "Loomian_Selection_Ranked.ogg"
+    type: warning
+  - id: ranked_battle_theme
+    title: "Ranked Battle Theme"
+    path: "ranked.txtp"
+    type: battle
+  - id: battle_vs_dr_vanta
+    title: "Battle Vs Dr. Vanta"
+    path: "vanta.txtp" #probably the best looping I could eyeball. Could adjust later if needed
+    type: battle
+  - id: severe_thunderstorm
+    title: "Severe Thunderstorm"
+    path: "Severe_Thunderstorm.ogg"
+    type: betting
+  - id: aranatta_trench
+    title: "Aranatta Trench"
+    path: "Aranatta_Trench.ogg"
+    type: break
+  - id: atlanthian_arcade
+    title: "Atlanthian Arcade"
+    path: "Atlanthian_Arcade.ogg"
+    type: betting
+  - id: raid_battle_theme
+    title: "Raid Battle Theme"
+    path: "raid.txtp"
+    type: battle
+  - id: dire_situation
+    title: "Dire Situation"
+    path: "Lotusun_Beach_Cutscene.ogg"
+    type: warning
 ...

--- a/Mario & Luigi - Bowser's Inside Story/metadata.yaml
+++ b/Mario & Luigi - Bowser's Inside Story/metadata.yaml
@@ -24,7 +24,7 @@ songs:
   - id: okey_dokey
     title: "Okey Dokey!!"
     path: "Okey Dokey!!.mini2sf"
-    type: warning
+    type: battle
   - id: boss_battle_mlbowser
     title: "Boss Battle"
     path: "Boss Battle.brstm"
@@ -32,7 +32,7 @@ songs:
   - id: showtime_mlbowser
     title: "SHOWTIME!"
     path: "SHOWTIME!.mini2sf"
-    type: warning
+    type: battle
   - id: in_the_final
     path: "38 In The Final.mini2sf"
     title: "In The Final (Final Battle)"

--- a/Mario Kart 8/metadata.yaml
+++ b/Mario Kart 8/metadata.yaml
@@ -193,7 +193,7 @@ songs:
     type: result
   - id: dragon_driftway_final_lap
     title: "Dragon Driftway (Final Lap)"
-    path: "pBGM_WU_DOSSUN_F_MAIN.txtp"
+    path: "pBGM_WU_DRAGONROAD_F_MAIN.txtp"
     type: battle
   - id: animal_crossing_results
     title: "Animal Crossing Results"

--- a/NHL 96/metadata.yaml
+++ b/NHL 96/metadata.yaml
@@ -1,0 +1,9 @@
+id: nhl_96
+title: "NHL '96"
+year: 1995
+platform: ["SNES", "Genesis", "DOS", "GB"]
+songs:
+  - id: get_ready_for_this
+    title: "Get Ready For This"
+    path: "NHL 96 title.spc"
+    type: betting

--- a/Pizza Tower/metadata.yaml
+++ b/Pizza Tower/metadata.yaml
@@ -224,4 +224,8 @@ songs:
     title: "Wudpecker"
     path: "Wudpecker.brstm"
     type: betting
+  - id: impasta_syndrome
+    title: "Impasta Syndrome"
+    path: "Impasta Syndrome.brstm"
+    type: betting
 ...

--- a/Pokemon Black 2/metadata.yaml
+++ b/Pokemon Black 2/metadata.yaml
@@ -367,4 +367,8 @@ songs:
     title: "Musical: Meloettaaa!!!"
     path: "Musical Meloettaaa!!!.brstm"
     type: result
+  - id: battle_sinnoh_gym_leader_beta
+    title: "Battle! (Sinnoh Gym Leader - Beta)"
+    path: "Battle! Gym Leader (Sinnoh Version) (Beta).brstm"
+    type: battle
 ...

--- a/Pokemon Black/metadata.yaml
+++ b/Pokemon Black/metadata.yaml
@@ -584,4 +584,8 @@ songs:
     title: "Farewell (Refrain)"
     path: "Sayonara -Refrain- (Sayonara - N's Farewell Remix).brstm"
     type: break
+  - id: battle_wild_pokemon_beta_bw
+    title: "Battle! Wild Pokémon (Beta)"
+    path: "Battle! Wild Pokémon (Beta).brstm"
+    type: battle
 ...

--- a/Pokemon Masters/metadata.yaml
+++ b/Pokemon Masters/metadata.yaml
@@ -389,6 +389,10 @@ songs:
     title: "Ultimate Battle! (Giovanni)"
     path: "bgm_battle_sakaki_03.logg"
     type: battle
+  - id: giovanni_s_goal
+    title: "Giovanni's Goal"
+    path: "bgm_battle_sakaki_04.logg"
+    type: betting #Game Freak why do you make this a battle track
   - id: battle_kanto_legendary_pokemon
     title: "Battle! (Kanto Legendary Pokémon)"
     path: "bgm_battle_legend_kanto.logg"
@@ -1015,6 +1019,10 @@ songs:
     title: "Decisive Battle! (Leon)"
     path: "bgm_battle_dande_02.logg"
     type: battle
+  - id: glorious_battle_leon
+    title: "Glorious Battle! (Leon)"
+    path: "bgm_battle_dande_ax.logg"
+    type: battle
   - id: battle_oleana_masters
     title: "Battle! (Oleana)"
     path: "bgm_battle_olive.logg"
@@ -1076,6 +1084,14 @@ songs:
   - id: battle_team_star_boss_eri
     title: "Battle! (Team Star Boss: Eri)"
     path: "bgm_battle_star_biwa.logg"
+    type: battle
+  - id: battle_team_star_boss_mela
+    title: "Battle! (Team Star Boss: Mela)"
+    path: "bgm_battle_star_meroko.logg"
+    type: battle
+  - id: battle_team_star_boss_atticus
+    title: "Battle! (Team Star Boss: Atticus)"
+    path: "bgm_battle_star_shuumei.logg"
     type: battle
   - id: battle_penny
     title: "Battle! (Penny)"
@@ -1187,6 +1203,10 @@ songs:
     title: "Battle! (Deck The Halls)"
     path: "bgm_battle_christmas.logg"
     type: battle
+  - id: starlight_harmony
+    title: "Starlight Harmony"
+    path: "bgm_battle_christmas_02.logg"
+    type: break #why a battle track again, GF
   - id: battle_new_year_masters
     title: "Battle! (New Year)"
     path: "bgm_battle_newyear.logg"

--- a/Pokemon Omega Ruby/metadata.yaml
+++ b/Pokemon Omega Ruby/metadata.yaml
@@ -405,4 +405,20 @@ songs:
     title: "Battle! (Frontier Brain)"
     path: "bgm_sg_vs_bfrontier.dspadpcm.bcstm"
     type: battle
+  - id: title_screen_beta_oras
+    title: "Title Screen (Beta)"
+    path: "Title Screen (Beta).brstm"
+    type: result
+  - id: battle_team_aqua_team_magma_leaders_beta_oras
+    title: "Battle! (Team Aqua / Team Magma Leaders - Beta)"
+    path: "Battle! Team Aqua _ Team Magma Leaders (Beta).brstm"
+    type: battle
+  - id: battle_gym_leader_beta_oras
+    title: "Battle! (Gym Leader - Beta)"
+    path: "Battle! Gym Leader (Beta).brstm"
+    type: battle
+  - id: battle_champion_beta_oras
+    title: "Battle! (Champion - Beta)"
+    path: "Battle! Champion (Beta).brstm"
+    type: battle
 ...

--- a/Pokemon Scarlet & Violet/metadata.yaml
+++ b/Pokemon Scarlet & Violet/metadata.yaml
@@ -4,7 +4,6 @@ title: "Pokémon Scarlet & Violet"
 series: pokemon
 platform: "Switch"
 year: 2022
-#very basic setup atm. Had to get assistance for these initial songs, had to wing the song titles. songs are sorted by the order they appear in the files, for clarity - always open to suggestions for improvement, same as with Legends Arceus
 songs:
   - id: ello_ello_hola_ciao_and_bonjour
     title: "'Ello, 'Ello, Hola! Ciao and Bonjour!"
@@ -30,8 +29,8 @@ songs:
     title: "Victory! (Trainer)"
     path: "BGM-00282.txtp"
     type: result
-  - id: battle_western_pokemon
-    title: "Battle! (Western Pokémon)"
+  - id: battle_west_province_wild_pokemon
+    title: "Battle! (West Province Wild Pokémon)"
     path: "BGM-00295.txtp"
     type: battle
   - id: artazon
@@ -58,12 +57,12 @@ songs:
     title: "Levincia"
     path: "BGM-00311.txtp"
     type: betting
-  - id: battle_southern_pokemon
-    title: "Battle! (Southern Pokémon)"
+  - id: battle_south_province_wild_pokemon
+    title: "Battle! (South Province Wild Pokémon)"
     path: "BGM-00316.txtp"
     type: battle
-  - id: battle_northern_pokemon
-    title: "Battle! (Northern Pokémon)"
+  - id: battle_north_province_wild_pokemon
+    title: "Battle! (North Province Wild Pokémon)"
     path: "BGM-00318.txtp"
     type: battle
   - id: a_stroll_through_the_south_province
@@ -82,8 +81,8 @@ songs:
     title: "Los Platos"
     path: "BGM-00322.txtp"
     type: betting
-  - id: battle_eastern_pokemon
-    title: "Battle! (Eastern Pokémon)"
+  - id: battle_east_province_wild_pokemon
+    title: "Battle! (East Province Wild Pokémon)"
     path: "BGM-00334.txtp"
     type: battle
   - id: a_stroll_through_the_east_province
@@ -107,7 +106,7 @@ songs:
     path: "BGM-00375.txtp"
     type: battle
   - id: battle_paradise_protection_protocol_koraidon_miraidon
-    title: "Battle! (■■■■)"
+    title: "Battle! (■■■)"
     path: "BGM-00376.txtp"
     type: battle
   - id: battle_titan
@@ -159,12 +158,12 @@ songs:
     title: "Battle! (Champion_Nemona)"
     path: "BGM-00457.txtp"
     type: battle
-  - id: battle_the_top_champion_geeta
-    title: "Battle! (The Top Champion)"
+  - id: battle_top_champion_geeta
+    title: "Battle! (Top Champion)"
     path: "BGM-00458.txtp"
     type: battle
-  - id: battle_ruinous_legend
-    title: "Battle! (Ruinous Legend)"
+  - id: battle_calamity_pokemon
+    title: "Battle! (Calamity Pokémon)"
     path: "BGM-00463.txtp"
     type: battle
   - id: the_academy_ace_tournament
@@ -172,7 +171,7 @@ songs:
     path: "BGM-00464.txtp"
     type: battle
   - id: tera_raid_battle
-    title: "Tera Raid Battle!"
+    title: "Tera Raid Battle"
     path: "BGM-00466.txtp"
     type: battle
   - id: battle_arven
@@ -191,8 +190,8 @@ songs:
     title: "Clive's True Identity"
     path: "PLAY_BGM_TI_EV_EXC_10.txtp"
     type: warning
-  - id: pokemon_league_interview_phase
-    title: "Pokémon League - Interview Phase"
+  - id: the_pokemon_league_interview
+    title: "The Pokémon League Interview"
     path: "BGM-00697.txtp"
     type: betting
   - id: let_s_make_a_sandwich
@@ -200,60 +199,60 @@ songs:
     path: "BGM-00738.txtp"
     type: betting
 # Main Game Tracks I missed the first time around (the txtp names changed but that's it)
-  - id: go_through_the_cave_in_the_cove
-    title: "Go Through the Cave in the Cove"
+  - id: going_through_the_inlet_grotto
+    title: "Going through the Inlet Grotto"
     path: "PLAY_BGM_TI_EV_EXC_01 (R01=D01) {s}=.txtp"
     type: betting
-  - id: battle_in_the_cave
-    title: "Battle In The Cave"
+  - id: battle_in_the_grotto
+    title: "Battle in the Grotto"
     path: "PLAY_BGM_TI_EV_EXC_01 (R01=D01) {s}=-.txtp"
     type: warning
-  - id: confront_the_titan_pokemon_again
-    title: "Confront the Titan Pokémon Again"
+  - id: second_battle_against_the_titan
+    title: "Second Battle against the Titan"
     path: "PLAY_BGM_TI_VS_NS (VS_NS=READY).txtp"
     type: warning
   - id: mesagoza
     title: "Mesagoza"
     path: "PLAY_BGM_FIELD_SDC02 (SDC02_REGION=BB_SCH)(SDC02_BB_SCH=CLUBROOM)(CLUBROOM=16) {s}=(C01_MUSICIAN=IN).txtp"
     type: betting
-  - id: one_song_in_mesagoza_if_you_please
-    title: "One Song In Mesagoza, If You Please"
+  - id: a_tune_at_mesagoza
+    title: "A Tune at Mesagoza"
     path: "PLAY_BGM_SOUTH_FIELD_FIRST (SOUTH_REGION=C01)(C01=C01)(C01_EV=ON) {s}=(C01_MUSICIAN=IN).txtp"
     type: betting
-  - id: the_academy_your_room
-    title: "The Academy - Your Room"
+  - id: your_dorm_room
+    title: "Your Dorm Room"
     path: "PLAY_BGM_SOUTH_FIELD_FIRST (SOUTH_REGION=C01)(C01=SCH_QUIET) {s}=(C01_MUSICIAN=IN).txtp"
     type: break
-  - id: let_s_try_to_get_stronger
-    title: "Let's Try to Get Stronger!"
+  - id: becoming_stronger_scarlet_violet
+    title: "Becoming Stronger"
     path: "PLAY_BGM_TI_EV_CMN_02_0285 (MAP_JUMP=END)(EV_COMMON_0285=ON).txtp"
     type: warning
-  - id: it_s_a_test_of_strength
-    title: "It's a Test of Strength!"
+  - id: a_test_of_strength_scarlet_violet
+    title: "A Test of Strength"
     path: "PLAY_BGM_TI_EV_CMN_03.txtp"
     type: warning
-  - id: right_now_i_m_clive
-    title: "Right Now I'm Clive"
+  - id: the_name_s_clive
+    title: "The Name's Clive"
     path: "PLAY_BGM_TI_EV_CMN_06.txtp"
     type: warning
-  - id: phone_call_from_cassiopeia
-    title: "Phone Call from Cassiopeia"
+  - id: a_call_from_cassiopeia
+    title: "A Call from Cassiopeia"
     path: "PLAY_BGM_TI_EV_CMN_07.txtp"
     type: warning
-  - id: just_a_moment_scarlet_violet
-    title: "Just a Moment"
+  - id: a_brief_moment_scarlet_violet
+    title: "A Brief Moment"
     path: "PLAY_BGM_TI_EV_CMN_08.txtp"
     type: result
   - id: team_star
-    title: "Team Star!"
+    title: "Team Star"
     path: "PLAY_BGM_TI_EV_EXC_03.txtp"
     type: warning
   - id: treasure_of_the_stars
     title: "Treasure of the Stars"
     path: "PLAY_BGM_TI_EV_EXC_04.txtp"
     type: break
-  - id: with_nemona
-    title: "With Nemona"
+  - id: together_with_nemona
+    title: "Together with Nemona"
     path: "PLAY_BGM_TI_EV_EXC_02.txtp"
     type: break
   - id: earnest_feelings_scarlet_violet
@@ -264,12 +263,12 @@ songs:
     title: "Reunion"
     path: "PLAY_BGM_TI_EV_EXC_09.txtp"
     type: warning
-  - id: gym_lobby_scarlet_violet
-    title: "Gym Lobby"
+  - id: gym_reception_scarlet_violet
+    title: "Gym Reception"
     path: "PLAY_BGM_TI_FC_GYM_FRONT.txtp"
     type: betting
-  - id: pokemon_league_scarlet_violet
-    title: "Pokémon League"
+  - id: the_pokemon_league_scarlet_violet
+    title: "The Pokémon League"
     path: "PLAY_BGM_TI_FC_PL11.txtp"
     type: betting
   - id: pokemon_center_scarlet_violet
@@ -281,7 +280,7 @@ songs:
     path: "PLAY_BGM_TI_EV_EXC_06.txtp"
     type: warning
   - id: the_opening_act_scarlet_violet
-    title: "The Opening Act"
+    title: "The Opening Act!"
     path: "PLAY_BGM_FIELD_SDC02 (SDC02_REGION=BB_SCH)(SDC02_BB_SCH=CLUBROOM)(CLUBROOM=24).txtp"
     type: betting
   - id: emotional_spectrum_practice
@@ -296,8 +295,8 @@ songs:
     title: "Gym Test"
     path: "PLAY_BGM_TI_FI_GYM_TRAINING_MUSHI (GYM_TEST_MUSHI_SAVE=ON)(MAP_JUMP=END)(GYM_TEST_MUSHI=READY).txtp"
     type: betting
-  - id: the_gym_test_s_not_over
-    title: "The Gym Test's Not Over!"
+  - id: still_at_the_gym_test
+    title: "Still at the Gym Test"
     path: "PLAY_BGM_TI_FI_MINIGAME_MIZU (MINI_GAME_MIZU=READY).txtp"
     type: warning
   - id: title_screen_scarlet_violet
@@ -308,24 +307,24 @@ songs:
     title: "Mystery Gift"
     path: "PLAY_BGM_TI_ST_04 (SYSTEM_DEMO=PLAY).txtp"
     type: warning
-  - id: welcome_to_the_paldea_region
-    title: "Welcome to the Paldea Region!"
+  - id: welcome_to_paldea
+    title: "Welcome to Paldea!"
     path: "PLAY_BGM_TI_ST_07 (FIRST_AWAKE=ON).txtp"
     type: betting
-  - id: battle_stadium_scarlet_violet
-    title: "Battle Stadium"
+  - id: the_battle_stadium_scarlet_violet
+    title: "The Battle Stadium"
     path: "PLAY_BGM_TI_ST_08.txtp"
     type: warning
-  - id: let_s_eat_scarlet_violet
-    title: "Let's Eat!"
+  - id: time_to_eat_scarlet_violet
+    title: "Time to Eat"
     path: "PLAY_BGM_TI_ST_EAT.txtp"
     type: result
-  - id: team_star_boss_appears
-    title: "Team Star Boss Appears!"
+  - id: a_team_star_boss_appears
+    title: "A Team Star Boss Appears!"
     path: "PLAY_BGM_TI_VS_TEAM_BOSS (VS_TEAM_BOSS=INTRO).txtp"
     type: warning
-  - id: c_mon_let_s_raid_the_place
-    title: "C'mon, Let's Raid the Place!"
+  - id: raiding_the_base
+    title: "Raiding the Base"
     path: "PLAY_BGM_TI_VS_TEAM_RUSH_WILD_READY.txtp"
     type: warning
   - id: victory_team_star_boss
@@ -380,8 +379,8 @@ songs:
     title: "East Province"
     path: "PLAY_BGM_SOUTH_FIELD_FIRST (EAST_REGION=FIELD)(EAST_AREA=NORMAL)(RIDE=ON).txtp"
     type: betting
-  - id: north_province_area_2
-    title: "North Province (Area 2)"
+  - id: north_province_area_two
+    title: "North Province (Area Two)"
     path: "PLAY_BGM_SOUTH_FIELD_FIRST (NORTH_REGION=FIELD)(NORTH_AREA=W22)(RIDE=ON).txtp"
     type: betting
   - id: north_province
@@ -397,8 +396,8 @@ songs:
     title: "Relic Song"
     path: "BGM-5015-event (S2_SUB_003=LOOP).txtp"
     type: betting
-  - id: flying_time_trial
-    title: "Flying Time Trial!"
+  - id: the_flying_time_trial
+    title: "The Flying Time Trial"
     path: "PLAY_4KINGS_CHALLENGE_B (CHALLENGE_B=GAME).txtp"
     type: warning
   - id: area_zero_underdepths
@@ -445,12 +444,12 @@ songs:
     title: "Terarium (Central Plaza)"
     path: "PLAY_BGM_FIELD_SDC02 (SDC02_REGION=DOME)(SDC02_DOME_AREA=SDC02_4KINGS_A_AREA).txtp"
     type: break
-  - id: to_the_dome
-    title: "To The Dome"
+  - id: to_the_terarium
+    title: "To the Terarium"
     path: "PLAY_BGM_FIELD_SDC02 (SDC02_REGION=DOME)(SDC02_DOME_AREA=SDC02_APPROACH)(SDC02_0060=ON)(AP_IN_OUT=BGM_AP_IN).txtp"
     type: break
-  - id: history_of_the_signboard
-    title: "History of the Signboard"
+  - id: historic_signboard
+    title: "Historic Signboard"
     path: "PLAY_BGM_SU1_EV_CMN_01.txtp"
     type: betting
   - id: briar_s_theme
@@ -465,24 +464,24 @@ songs:
     title: "With Perrin"
     path: "PLAY_BGM_SU1_EV_CMN_04.txtp"
     type: result
-  - id: distortion_scarlet_violet
-    title: "Distortion"
+  - id: twisted_scarlet_violet
+    title: "Twisted"
     path: "PLAY_BGM_SU1_EV_CMN_05.txtp"
     type: warning
-  - id: they_re_relaxed_now
-    title: "They're Relaxed Now"
+  - id: a_moment_of_honesty_scarlet_violet
+    title: "A Moment of Honesty"
     path: "PLAY_BGM_SU1_EV_CMN_06.txtp"
     type: result
-  - id: the_loyal_three_wreaks_havoc
-    title: "The Loyal Three Wreaks Havoc"
+  - id: the_loyal_three_cause_trouble
+    title: "The Loyal Three Cause Trouble"
     path: "PLAY_BGM_SU1_EV_CMN_07.txtp"
     type: warning
   - id: perrin_s_theme
     title: "Perrin's Theme"
     path: "PLAY_BGM_SU1_EV_CMN_08.txtp"
     type: betting
-  - id: the_real_history
-    title: "The Real History"
+  - id: the_true_history
+    title: "The True History"
     path: "PLAY_BGM_SU1_EV_EXC_02.txtp"
     type: break
   - id: ogre_oustin
@@ -494,63 +493,63 @@ songs:
     path: "PLAY_BGM_SU1_ST_ONIBALLOON (ONIBALLOON=INTER).txtp"
     type: warning
   - id: photography_march
-    title: "Photography (March)"
+    title: "Photography (Pokémon March)"
     path: "PLAY_BGM_SU1_ST_PHOTO_01.txtp"
     type: warning
-  - id: photography_victory
-    title: "Photography (Victory)"
+  - id: photography_battle
+    title: "Photo (Battle)"
     path: "PLAY_BGM_SU1_ST_PHOTO_02.txtp"
     type: warning
   - id: photography_lullaby
-    title: "Photography (Lullaby)"
+    title: "Photo (Pokémon Lullaby)"
     path: "PLAY_BGM_SU1_ST_PHOTO_03.txtp"
     type: break
   - id: caught_ogerpon
-    title: "Caught Ogerpon"
+    title: "Caught Ogerpon!"
     path: "PLAY_BGM_SU1_VS_KAMENONI (VS_KAMENONI=CAP_SUCCESS).txtp"
     type: result
-  - id: daily_life_at_the_academy
-    title: "Daily Life at the Academy"
+  - id: a_regular_day_at_bb_academy
+    title: "A Regular Day at BB Academy"
     path: "PLAY_BGM_SU2_EV_CMN_02.txtp"
     type: warning
   - id: unsettling_atmosphere_scarlet_violet
     title: "Unsettling Atmosphere"
     path: "PLAY_BGM_SU2_EV_CMN_05.txtp"
     type: warning
-  - id: true_intentions_scarlet_violet
-    title: "True Intentions"
+  - id: true_feelings_scarlet_violet
+    title: "True Feelings"
     path: "PLAY_BGM_SU2_EV_CMN_06.txtp"
     type: break
-  - id: the_defeated_kieran
-    title: "The Defeated Kieran"
+  - id: kieran_defeated
+    title: "Kieran Defeated"
     path: "PLAY_BGM_SU2_EV_CMN_07.txtp"
     type: warning
   - id: mochi_mayhem
     title: "Mochi Mayhem!"
     path: "PLAY_BGM_SU2_EV_CMN_08_VS (VS_TR_CMN_EV_SDC=EYE_SDC) {s}=(CMN_08_VOL=ON).txtp"
     type: battle
-  - id: star_training_centers_team_star
-    title: "Star Training Centers! Team Star"
+  - id: studying_together_with_team_star
+    title: "Studying Together with Team Star"
     path: "PLAY_BGM_SU2_EV_CMN_10.txtp"
     type: betting
-  - id: this_is_the_terarium_dome
-    title: "This is the Terarium Dome!"
+  - id: welcome_to_the_Terarium
+    title: "Welcome to the Terarium!"
     path: "PLAY_BGM_SU2_EV_DOME_START.txtp"
     type: betting
   - id: title_screen_2_scarlet_violet
     title: "Title Screen 2"
     path: "PLAY_BGM_SU2_ST_11.txtp"
     type: break
-  - id: catching_terapagos
-    title: "Catching Terapagos"
+  - id: caught_terapagos
+    title: "Caught Terapagos!"
     path: "PLAY_BGM_SU2_VS_KODAIGAME (KODAIGAME=CAP_START) {s}=(CAP=ON).txtp"
     type: result
-  - id: terapagos_awakens
-    title: "Terapogos Awakens"
+  - id: terapagos_reawakened
+    title: "Terapagos Reawakened"
     path: "PLAY_BGM_SU2_VS_KODAIGAME (KODAIGAME=EV).txtp"
     type: warning
-  - id: battle_pokemon_in_kitakami
-    title: "Battle! (Pokémon in Kitakami)"
+  - id: battle_kitakami_pokémon
+    title: "Battle! (Kitakami Pokémon)"
     path: "PLAY_VS_SELECT_SDC01 (TYPE_SDC01=28).txtp"
     type: battle
   - id: battle_carmine
@@ -594,15 +593,15 @@ songs:
     path: "PLAY_VS_SELECT_SDC02 (TYPE_SDC02=39).txtp"
     type: battle
   - id: battle_terapagos_the_hidden_treasure_of_area_zero
-    title: "Battle! (Terapagos - The Hidden Treasure of Area Zero)"
+    title: "Battle! (Terapagos, The Hidden Treasure of Area Zero)"
     path: "PLAY_VS_SELECT_SDC02 (TYPE_SDC02=40).txtp"
     type: battle
   - id: battle_pecharunt
     title: "Battle! (Pecharunt)"
     path: "PLAY_VS_SELECT_SDC02 (TYPE_SDC02=56).txtp"
     type: battle
-  - id: battle_tera_pokemon_in_the_terarium
-    title: "Battle! (Tera Pokémon in the Terarium)"
+  - id: battle_terarium_tera_pokémon
+    title: "Battle! (Terarium Tera Pokémon)"
     path: "PLAY_VS_SELECT_SDC02 (TYPE_SDC02=57).txtp"
     type: battle
 ...

--- a/Pokemon X/metadata.yaml
+++ b/Pokemon X/metadata.yaml
@@ -518,4 +518,32 @@ songs:
     path: "bgm_xy_ending.aac"
     ends: 2:38
     type: betting
+  - id: route_6_unova_xy
+    title: "Route 6 (Unova - Unused)"
+    path: "Route 6 (Black & White).brstm"
+    type: betting
+  - id: critical_health_xy
+    title: "Critical Health (Unused)"
+    path: "Critical Health.brstm"
+    type: result
+  - id: battle_unovan_wild_pokemon_unused
+    title: "Battle! (Unovan Wild Pokémon - Unused)"
+    path: "Battle! Wild Pokémon (Black & White).brstm"
+    type: battle
+  - id: battle_mythical_pokemon
+    title: "Battle! Mythical Pokémon"
+    path: "Battle! Mythical Pokémon.brstm"
+    type: battle
+  - id: battle_friend_beta
+    title: "Battle! (Friend - Beta)"
+    path: "Battle! Friend (Beta).brstm"
+    type: battle
+  - id: battle_xerneas_yveltal_zygarde_beta
+    title: "Battle! (Xerneas/Yveltal/Zygarde - Beta)"
+    path: "Battle! Xerneas_Yveltal (Beta).brstm"
+    type: battle
+  - id: battle_mythical_pokemon_beta
+    title: "Battle! Mythical Pokémon (Beta)"
+    path: "Battle! Mythical Pokémon (Beta).brstm"
+    type: battle
 ...

--- a/Road Fighters 3D/metadata.yaml
+++ b/Road Fighters 3D/metadata.yaml
@@ -1,0 +1,63 @@
+---
+id: road_fighters_3d
+title: "Road Fighters 3D"
+platform: "Arcade"
+year: 2010
+songs: 
+  - id: next_mission_rf3d
+    title: "Next Mission"
+    path: "Next Mission.brstm"
+    type: warning
+  - id: mission_rf3d
+    title: "Mission"
+    path: "Mission.brstm"
+    type: betting
+  - id: continue_rf3d
+    title: "Continue"
+    path: "Continue.brstm"
+    type: result
+  - id: danger_rf3d
+    title: "Danger!"
+    path: "Danger!.brstm"
+    type: warning
+  - id: result_rf3d
+    title: "Result"
+    path: "Result.brstm"
+    type: result
+  - id: time_attack_rf3d
+    title: "Time Attack"
+    path: "Time Attack.brstm"
+    type: betting
+  - id: mode_event
+    title: "Mode Event"
+    path: "Mode Event.brstm"
+    type: battle
+  - id: the_racer
+    title: "The Racer"
+    path: "The Racer.brstm"
+    type: betting
+  - id: mode_select_rf3d
+    title: "Mode Select"
+    path: "Mode Select.brstm"
+    type: betting
+  - id: speed_it_up
+    title: "Speed It Up"
+    path: "Speed It Up.brstm"
+    type: battle
+  - id: national_ranking
+    title: "National Ranking"
+    path: "National Ranking.brstm"
+    type: betting
+  - id: take_me_higher_instrumental
+    title: "Take Me Higher -Instrumental- (Road Fighters Main Theme)"
+    path: "Take Me Higher -Instrumental- (Road Fighters Main Theme).brstm"
+    type: betting
+  - id: take_me_higher_data_save
+    title: "Take Me Higher (Data Save)"
+    path: "Take Me Higher (Data Save).brstm"
+    type: betting
+  - id: take_me_higher_synthesized_2
+    title: "Take Me Higher [Synthesized 2]"
+    path: "Take Me Higher [Synthesized 2].brstm"
+    type: betting
+...

--- a/SiIvaGunner Rebooted/metadata.yaml
+++ b/SiIvaGunner Rebooted/metadata.yaml
@@ -1,7 +1,8 @@
 ---
-id: siivagunner_rebooted
-title: "SilvaGunner: Rebooted"
+id: siivatale_rebooted
+title: "SilvaTale: Rebooted"
 platform: "PC"
+series: siivagunner, undertale
 year: 2024
 is_fanwork: true
 # yes this is an Undertale fangame they released for a Christmas ARG. Yes it counts

--- a/Siivacraft/metadata.yaml
+++ b/Siivacraft/metadata.yaml
@@ -1,0 +1,182 @@
+---
+id: siivacraft
+title: "SiIvaCraft"
+series: minecraft, siivagunner
+platform: "PC"
+is_fanwork: true 
+year: 2022
+#can you guess it? Another SiIvaGunner mod! This one is for Minecraft, replacing all the music with equivalent rips
+#because all the music is in .ogg files and I'm too lazy to make looping .txtps for them all, I'm focusing right now on the ones that don't need to be looped
+#I can add others later if need be
+songs: 
+  - id: a_ruined_thirteenth
+    title: "A Ruined Thirteenth"
+    path: "13.ogg"
+    type: break
+  - id: air_blocks
+    title: "Air Blocks"
+    path: "blocks.ogg"
+    type: betting
+  - id: miicraft
+    title: "MiiCraft"
+    path: "cat.ogg"
+    type: betting
+  - id: don_t_chirp_loudly_when_ur_in_the_tunnel
+    title: "don't chirp loudly when ur in the tunnel"
+    path: "chirp.ogg"
+    type: betting
+  - id: cube_kirby_goes_mining_in_the_ruins
+    title: "Cube Kirby Goes Mining in the Ruins"
+    path: "far.ogg"
+    type: betting
+  - id: beedle_s_department_store
+    title: "Beedle's Department Store"
+    path: "mall.ogg"
+    type: break
+  - id: inside_the_woodland_mansion
+    title: "Inside the Woodland Mansion"
+    path: "mellohi.ogg"
+    type: warning
+  - id: when_you_put_casino_night_into_a_jukebox
+    title: "when you put casino night into a jukebox"
+    path: "stal.ogg"
+    ends: 1:47
+    type: betting
+  - id: you_re_free_wake_up
+    title: "You're free. Wake Up."
+    path: "strad.ogg"
+    type: break
+  - id: wait_when_are_we_now
+    title: "Wait, When Are We Now"
+    path: "wait.ogg"
+    type: break
+  - id: super_mario_ward
+    title: "Super Mario Ward"
+    path: "ward.ogg"
+    ends: 2:57
+    type: betting
+  - id: mutation_of_earth
+    title: "Mutation of Earth"
+    path: "menu1.ogg"
+    type: break
+  - id: another_dimension_of_mobs
+    title: "Another Dimension of Mobs"
+    path: "menu2.ogg"
+    type: break
+  - id: the_girl_who_plays_minecraft
+    title: "The Girl Who Plays Minecraft"
+    path: "menu3.ogg"
+    type: betting
+  - id: floating_dolphins
+    title: "Floating Dolphins"
+    path: "menu4.ogg"
+    type: break
+  - id: m_o_o_g_city
+    title: "M-O-O-G City"
+    path: "moogcity.ogg"
+    type: betting
+  - id: a_day_of_minecraft
+    title: "A Day of Minecraft"
+    path: "calm1.ogg"
+    type: break
+  - id: the_requiem_of_alex
+    title: "The Requiem of Alex"
+    path: "calm2.ogg"
+    type: break
+  - id: 12am_in_sweden
+    title: "12AM in Sweden"
+    path: "calm3.ogg"
+    type: break
+  - id: steve_s_nightmare
+    title: "Steve's Nightmare"
+    path: "chris.ogg"
+    ends: 2:05
+    type: betting
+  - id: new_world_machine
+    title: "New World Machine"
+    path: "hal1.ogg"
+    type: break #technically 8 seconds short but eh
+  - id: never_forgive_me_never_forger_me
+    title: "Never Forgive Me, Never Forger Me"
+    path: "hal2.ogg"
+    type: betting
+  - id: haggstrom_moon
+    title: "Haggstrom Moon"
+    path: "hal3.ogg"
+    type: break
+  - id: danny_is_you
+    title: "DANNY IS YOU"
+    path: "hal4.ogg"
+    type: break
+  - id: mario_kyoto
+    title: "Mario"
+    path: "kyoto.ogg"
+    type: break
+  - id: villagers_vs_zombies
+    title: "Villagers vs. Zombies"
+    path: "piano3.ogg"
+    type: break
+  - id: castle_of_the_nether_realm
+    title: "Castle of the Nether Realm"
+    path: "nether1.ogg"
+    ends: 2:24
+    type: betting
+  - id: steve_and_the_dead_forest
+    title: "Steve and the Dead Forest"
+    path: "nether2.ogg"
+    type: break
+  - id: hidden_in_the_third_dimension
+    title: "Hidden in the Third Dimension"
+    path: "nether3.ogg"
+    type: break
+  - id: ballad_of_the_dodongos
+    title: "Ballad of the Dodongos"
+    path: "nether4.ogg"
+    type: break
+  - id: forgotten_scrapbook
+    title: "Forgotten Scrapbook"
+    path: "scrapbook.ogg"
+    type: warning
+  - id: farewell_n_intro_minecraft
+    title: "iNtro"
+    path: "intro.ogg"
+    type: break
+  - id: fell_from_a_high_place_reprise
+    title: "Fell From a High Place (Reprise)"
+    path: "credits.ogg"
+    type: break
+  - id: worldwide_biome_fest
+    title: "Worldwide Biome Fest"
+    path: "creative1.ogg"
+    type: break
+  - id: a_sight_from_the_blind_spots
+    title: "A Sight from the Blind Spots"
+    path: "creative2.ogg"
+    type: break
+  - id: rauq_aazy
+    title: "Rauq Aazy"
+    path: "creative3.ogg"
+    ends: 3:35
+    type: betting
+  - id: acoustic_arithmetic
+    title: "Acoustic Arithmetic"
+    path: "creative4.ogg"
+    type: break
+  - id: the_end_s_outer_islands
+    title: "The End's Outer Islands"
+    path: "creative5.ogg"
+    type: break
+  - id: creation_break
+    title: "Creation Break"
+    path: "creative6.ogg"
+    type: break
+  - id: ruins_of_flake
+    title: "Ruins of Flake"
+    path: "flake.ogg"
+    type: betting
+  - id: droopy_likes_plok
+    title: "Droopy likes Plok"
+    path: "plok.ogg"
+    ends: 1:57
+    type: betting
+...

--- a/Sonic Forces/metadata.yaml
+++ b/Sonic Forces/metadata.yaml
@@ -153,4 +153,20 @@ songs:
     title: "Fist Bump (FM Ver.)"
     path: "Fist Bump (FM Ver.).brstm"
     type: betting
+  - id: enemy_territory_westopolis_remix
+    title: "Enemy Territory [Westopolis Remix]"
+    path: "bgm_stg43_sh.hca"
+    type: betting
+  - id: eggman_s_facility_rhythm_and_balance_remix
+    title: "Eggman's Facility [Rhythm and Balance Remix]"
+    path: "bgm_stg44_sh.hca"
+    type: betting
+  - id: virtual_reality_supporting_me_remix
+    title: "Virtual Reality [Supporting Me Remix]"
+    path: "bgm_stg45_sh.hca"
+    type: battle
+  - id: episode_shadow
+    title: "Episode Shadow"
+    path: "bgm_sys_worldmap_sh.hca"
+    type: warning
 ...

--- a/Sonic Robo Blast 2 v2.1/metadata.yaml
+++ b/Sonic Robo Blast 2 v2.1/metadata.yaml
@@ -61,7 +61,7 @@ songs:
   - id: blue_mountain_zone_act_2_unused
     title: "Blue Mountain Zone Act 2 (Unused)"
     path: "Blue Mountain Zone Act 2 (Unused).logg"
-    ends: 2:23
+    ends: 2:00
     type: betting
   - id: boss_battle_srb2_1
     title: "Boss Battle"

--- a/Sonic and the Fallen Star/metadata.yaml
+++ b/Sonic and the Fallen Star/metadata.yaml
@@ -1,0 +1,101 @@
+---
+id: sonic_and_the_fallen_star
+title: "Sonic and the Fallen Star"
+series: sonic
+is_fanwork: true
+platform: "PC"
+year: 2022
+songs: 
+  - id: green_is_the_color_gusty_greenhouse_act_1
+    title: "Green is the Color ~ Gusty Greenhouse Act 1"
+    path: "Green is the Color ~ Gusty Greenhouse Act 1.brstm"
+    type: betting
+  - id: life_in_a_greenhouse_gusty_greenhouse_act_2
+    title: "Life in a Greenhouse ~ Gusty Greenhouse Act 2"
+    path: "Life in a Greenhouse ~ Gusty Greenhouse Act 2.brstm"
+    type: betting
+  - id: rose_colored_rhythm_raspberry_river_act_1
+    title: "Rose-Colored Rhythm ~ Raspberry River Act 1"
+    path: "Rose-Colored Rhythm ~ Raspberry River Act 1.brstm"
+    type: break
+  - id: shattered_mural_raspberry_river_act_2
+    title: "Shattered Mural ~ Raspberry River Act 2"
+    path: "Shattered Mural ~ Raspberry River Act 2.brstm"
+    type: betting
+  - id: one_way_lane_tropical_tracks_act_1
+    title: "One Way Lane ~ Tropical Tracks Act 1"
+    path: "One Way Lane ~ Tropical Tracks Act 1.brstm"
+    type: betting
+  - id: sundown_fever_tropical_tracks_act_2
+    title: "Sundown Fever ~ Tropical Tracks Act 2"
+    path: "Sundown Fever ~ Tropical Tracks Act 2.brstm"
+    type: betting
+  - id: synthesthesia_discount_districts_act_1
+    title: "Synthesthesia ~ Discount Districts Act 1"
+    path: "Synthesthesia ~ Discount Districts Act 1.brstm"
+    type: betting
+  - id: sonic_s_last_night_in_town_discount_districts_act_2
+    title: "Sonic's Last Night in Town ~ Discount Districts Act 2"
+    path: "Sonic's Last Night in Town ~ Discount Districts Act 2.brstm"
+    type: betting
+  - id: amy_it_s_cold_outside_frozen_fountain_act_1
+    title: "Amy, It's Cold Outside ~ Frozen Fountain Act 1"
+    path: "Amy, It's Cold Outside ~ Frozen Fountain Act 1.brstm"
+    type: betting
+  - id: continental_lifts_frozen_fountain_act_2
+    title: "Continental Lifts ~ Frozen Fountain Act 2"
+    path: "Continental Lifts ~ Frozen Fountain Act 2.brstm"
+    type: battle
+  - id: hedgehog_over_the_horizon_sapphire_sights_act_1
+    title: "Hedgehog Over the Horizon ~ Sapphire Sights Act 1"
+    path: "Hedgehog Over the Horizon ~ Sapphire Sights Act 1.brstm"
+    type: betting
+  - id: free_in_the_marina_sapphire_sights_act_2
+    title: "Free in the Marina ~ Sapphire Sights Act 2"
+    path: "Free in the Marina ~ Sapphire Sights Act 2.brstm"
+    type: betting
+  - id: don_t_look_down_thunder_turbine_act_1
+    title: "Don't Look Down ~ Thunder Turbine Act 1"
+    path: "Don't Look Down ~ Thunder Turbine Act 1.brstm"
+    type: betting
+  - id: music_to_infiltrate_by_thunder_turbine_act_2
+    title: "Music to Infiltrate By ~ Thunder Turbine Act 2"
+    path: "Music to Infiltrate By ~ Thunder Turbine Act 2.brstm"
+    type: battle
+  - id: bridge_over_bubbling_water_bubble_blossom_act_1
+    title: "Bridge Over Bubbling Water ~ Bubble Blossom Act 1"
+    path: "Bridge Over Bubbling Water ~ Bubble Blossom Act 1.brstm"
+    type: betting
+  - id: confetti_cannon_to_paradise_bubble_blossom_act_2
+    title: "Confetti Cannon to Paradise ~ Bubble Blossom Act 2"
+    path: "Confetti Cannon to Paradise ~ Bubble Blossom Act 2.brstm"
+    type: betting
+  - id: this_keg_is_a_circus_carnival_crater_act_1
+    title: "This Keg is a Circus ~ Carnival Crater Act 1"
+    path: "This Keg is a Circus ~ Carnival Crater Act 1.brstm"
+    type: betting
+  - id: forged_in_the_fire_carnival_crater_act_2
+    title: "Forged in the Fire ~ Carnival Crater Act 2"
+    path: "Forged in the Fire ~ Carnival Crater Act 2.brstm"
+    type: battle
+  - id: subspace_distortion_supernova_mix_special_stage
+    title: "Subspace Distortion (Supernova Mix) ~ Special Stage"
+    path: "Subspace Distortion (Supernova Mix) ~ Special Stage.brstm"
+    type: battle
+  - id: danger_on_the_discount_line_vs_benedict_express
+    title: "Danger on the Discount Line ~ Vs. Benedict Express"
+    path: "Danger on the Discount Line ~ Vs. Benedict Express.brstm"
+    type: battle
+  - id: time_rift_shift_vs_metal_sonic
+    title: "Time Rift Shift ~ Vs. Metal Sonic"
+    path: "Time Rift Shift ~ Vs. Metal Sonic.brstm"
+    type: battle
+  - id: mean_bean_fighting_machine_vs_eggman_2
+    title: "Mean Bean Fighting Machine ~ Vs. Eggman #2"
+    path: "Mean Bean Fighting Machine ~ Vs. Eggman #2.brstm"
+    type: battle
+  - id: dance_of_the_pseudo_psycho_vs_final_boss
+    title: "Dance of the Pseudo-Psycho ~ Vs. Final Boss"
+    path: "Dance of the Pseudo-Psycho ~ Vs. Final Boss.brstm"
+    type: battle
+...

--- a/Sonic x Shadow Generations/metadata.yaml
+++ b/Sonic x Shadow Generations/metadata.yaml
@@ -1,0 +1,156 @@
+---
+id: sonic_shadow_generations
+title: "Sonic x Shadow Generations"
+series: sonicthehedgehog
+platform: "Various"
+year: 2024
+songs:
+  - id: space_colony_ark_act1_teddyloid_x_jun_senoue_remix
+    title: "Space Colony ARK: Act1 (TeddyLoid x Jun Senoue Remix)"
+    path: "bgm_w01a11.txtp"
+    type: battle
+  - id: space_colony_ark_act2
+    title: "Space Colony ARK: Act2"
+    path: "bgm_w01a20.txtp"
+    type: betting
+  - id: rail_canyon_act1
+    title: "Rail Canyon: Act1"
+    path: "bgm_w02a10.txtp"
+    type: betting
+  - id: rail_canyon_act2
+    title: "Rail Canyon: Act2"
+    path: "bgm_w02a20.txtp"
+    type: battle
+  - id: kingdom_valley_act1
+    title: "Kingdom Valley: Act1"
+    path: "bgm_w03a10.txtp"
+    type: betting
+  - id: kingdom_valley_act2
+    title: "Kingdom Valley: Act2"
+    path: "bgm_w03a20.txtp"
+    type: betting
+  - id: sunset_heights_act1
+    title: "Sunset Heights: Act1"
+    path: "bgm_w04a10.txtp"
+    type: battle
+  - id: sunset_heights_act2
+    title: "Sunset Heights: Act2"
+    path: "bgm_w04a20.txtp"
+    type: battle
+  - id: chaos_island_act1
+    title: "Chaos Island: Act1"
+    path: "bgm_w05a10.txtp"
+    type: betting
+  - id: chaos_island_act2
+    title: "Chaos Island: Act2"
+    path: "bgm_w05a20.txtp"
+    type: betting
+  - id: radical_highway_act1
+    title: "Radical Highway: Act1"
+    path: "bgm_w06a10.txtp"
+    type: battle
+  - id: radical_highway_act2
+    title: "Radical Highway: Act2"
+    path: "bgm_w06a20.txtp"
+    type: battle
+  - id: boss_battle_biolizard
+    title: "Boss Battle: Biolizard"
+    path: "bgm_w11b10.txtp"
+    type: battle
+  - id: boss_battle_metal_overlord_what_i_m_made_of
+    title: "Boss Battle: Metal Overlord (What I'm Made Of...)"
+    path: "bgm_w12b10.txtp"
+    type: battle
+  - id: boss_battle_mephiles_pt_1
+    title: "Boss Battle: Mephiles Pt.1"
+    path: "bgm_w13b10_1.txtp"
+    type: battle
+  - id: boss_battle_mephiles_pt_2
+    title: "Boss Battle: Mephiles Pt.2"
+    path: "bgm_w13b10_2.txtp"
+    type: battle
+  - id: boss_battle_devil_doom
+    title: "Boss Battle: Devil Doom"
+    path: "bgm_w14b10_1.txtp"
+    type: battle
+  - id: boss_battle_neo_devil_doom_all_hail_shadow_symphonic_ver
+    title: "Boss Battle: Neo Devil Doom (All Hail Shadow - Symphonic ver.)"
+    path: "bgm_w14b10_2.txtp"
+    type: battle
+  - id: event_finale_the_end_of_neo_devil_doom
+    title: "Event: Finale (The End of Neo Devil Doom)"
+    path: "bgm_w14b10_3.txtp"
+    type: result
+  - id: doom_zone_space_colony_ark_act1
+    title: "Doom Zone (Space Colony ARK: Act1)"
+    path: "bgm_distortionspace1.txtp"
+    type: battle
+  - id: doom_zone_rail_canyon_act1
+    title: "Doom Zone (Rail Canyon: Act1)"
+    path: "bgm_distortionspace2.txtp"
+    type: battle
+  - id: doom_zone_sunset heights_act1
+    title: "Doom Zone (Sunset Heights: Act1)"
+    path: "bgm_distortionspace3.txtp"
+    type: battle
+  - id: white_space
+    title: "White Space"
+    path: "bgm_whitespace.txtp"
+    type: betting
+  - id: white_space_underground
+    title: "White Space (Underground)"
+    path: "bgm_whitespace_under.txtp"
+    type: betting
+  - id: white_space_doom_zone
+    title: "White Space (Doom Zone)"
+    path: "bgm_whitespace_eclipse.txtp"
+    type: betting
+  - id: title_sonic_x_shadow_generations
+    title: "Title (Sonic x Shadow Generations)"
+    path: "bgm_titlecmn.txtp"
+    type: betting
+  - id: title_sonic_generations
+    title: "Title (Sonic Generations)"
+    path: "bgm_title2select_titlegen.txtp"
+    type: result
+  - id: title_shadow_generations
+    title: "Title (Shadow Generations)"
+    path: "bgm_title2select_titleshadow.txtp"
+    type: warning
+  - id: challenge_shadow_generations
+    title: "Challenge"
+    path: "bgm_wschallenge1.txtp"
+    type: warning
+  - id: collection_room_shadow_generations
+    title: "Collection Room"
+    path: "bgm_collectionmenu.txtp"
+    type: break
+  - id: gate_space_colony_ark
+    title: "Gate: Space Colony ARK"
+    path: "bgm_gate_zone1.txtp"
+    type: warning
+  - id: gate_rail_canyon
+    title: "Gate: Rail Canyon"
+    path: "bgm_gate_zone2.txtp"
+    type: warning
+  - id: gate_kingdom_valley
+    title: "Gate: Kingdom Valley"
+    path: "bgm_gate_zone3.txtp"
+    type: warning
+  - id: gate_sunset_heights
+    title: "Gate: Sunset Heights"
+    path: "bgm_gate_zone4.txtp"
+    type: warning
+  - id: gate_chaos_island
+    title: "Gate: Chaos Island"
+    path: "bgm_gate_zone5.txtp"
+    type: warning
+  - id: gate_radical_highway
+    title: "Gate: Radical Highway"
+    path: "bgm_gate_zone6.txtp"
+    type: warning
+  - id: gate_boss_shadow_generations
+    title: "Gate: Boss"
+    path: "bgm_gate_boss.txtp"
+    type: warning
+...

--- a/Super Kirby Clash/metadata.yaml
+++ b/Super Kirby Clash/metadata.yaml
@@ -145,12 +145,12 @@ songs:
     title: "Ultra-Super Boss Battle"
     path: "BGM_SuperCopyBoss07_RMX.dspadpcm.bfstm"
     type: battle
-  - id: deux_ex_machina_seen_in_childhood_super_kirby_clash
-    title: "Deus · Ex · Machina Seen in Childhood"
+  - id: a_deus_ex_machina_from_childhood_super_kirby_clash
+    title: "A Deus Ex Machina from Childhood"
     path: "BGM_RBBBoss_RMX.dspadpcm.bfstm"
     type: battle
-  - id: phantom_of_the_moon_super_kirby_clash
-    title: "Phantom of the Moon"
+  - id: phantom_of_the_moon_soul_super_kirby_clash
+    title: "Phantom of the Moon Soul"
     path: "BGM_Taranza_RMX.dspadpcm.bfstm"
     type: battle
   - id: heroes_in_another_dimension_super_kirby_clash

--- a/Super Mario Eclipse/metadata.yaml
+++ b/Super Mario Eclipse/metadata.yaml
@@ -1,0 +1,77 @@
+---
+id: super_mario_eclipse
+title: "Super Mario Eclipse"
+platform: "GCN"
+series: mario
+is_fanwork: true 
+year: 2021
+songs:
+  - id: tutorial_eclipse
+    title: "Tutorial"
+    path: "Tutorial.brstm"
+    type: break
+  - id: character_select_eclipse
+    title: "Character Select"
+    path: "Character Select.brstm"
+    type: betting
+  - id: hotel_lacrima_outside
+    title: "Hotel Lacrima (Outside)"
+    path: "Hotel Lacrima (Outside).brstm"
+    type: break
+  - id: hotel_lacrima_mafia
+    title: "Hotel Lacrima (Mafia)"
+    path: "Hotel Lacrima (Mafia).brstm"
+    type: betting
+  - id: daisy_cruiser_peach_beach_eclipse
+    title: "Daisy Cruiser / Peach Beach"
+    path: "Daisy Cruiser _ Peach Beach.brstm"
+    type: betting
+  - id: lancia_fredda_secret_course
+    title: "Lancia Fredda Secret Course"
+    path: "Lancia Fredda Secret Course.brstm"
+    type: break
+  - id: erto_rock
+    title: "Erto Rock"
+    path: "Erto Rock.brstm"
+    type: betting
+  - id: daisy_cruiser_cabin
+    title: "Daisy Cruiser Cabin"
+    path: "Daisy Cruiser Cabin.brstm"
+    type: break
+  - id: memphis_vaporwave_ost_ver
+    title: "Memphis Vaporwave (OST Ver.)"
+    path: "Memphis Vaporwave (OST Ver.).brstm"
+    type: betting
+  - id: pianta_pit
+    title: "Pianta Pit"
+    path: "Pianta Pit.brstm"
+    type: warning
+  - id: lighthouse_island_stormy
+    title: "Lighthouse Island (Stormy)"
+    path: "Lighthouse Island (Stormy).brstm"
+    type: warning
+  - id: 2d_world_secret_courses
+    title: "2D World / Secret Courses"
+    path: "2D World _ Secret Courses.brstm"
+    type: betting
+  - id: yoshi_village_eclipse
+    title: "Yoshi Village"
+    path: "Yoshi Village.brstm"
+    type: betting
+  - id: red_lily_city
+    title: "Red Lily City"
+    path: "Red Lily City.brstm"
+    type: break
+  - id: lancia_fredda_peaks
+    title: "Lancia Fredda Peaks"
+    path: "Lancia Fredda Peaks.brstm"
+    type: betting
+  - id: warship_island
+    title: "Warship Island"
+    path: "Warship Island.brstm"
+    type: betting
+  - id: warship_island_secret_course
+    title: "Warship Island Secret Course"
+    path: "Warship Island Secret Course.brstm"
+    type: break
+...

--- a/Super Monkey Ball Musical Monkey Madness/metadata.yaml
+++ b/Super Monkey Ball Musical Monkey Madness/metadata.yaml
@@ -1,0 +1,175 @@
+---
+id: super_monkey_ball_musical_monkey_madness
+title: "Super Monkey Ball: Musical Monkey Madness"
+series: supermonkeyball, siivagunner
+is_fanwork: true
+platform: "PC"
+year: 2022
+#so this is an event that SiIvagunner did a couple years back where they made a bunch of Super Monkey Ball remixes
+#and also made them into a mod you can play for Banana Mania
+songs:
+  - id: main_theme_finnsfolks_remix
+    title: "Menu Theme (Finnsfolks Remix)"
+    path: "adv.awb"
+    type: betting
+  - id: jungle_island_rom_m_mix
+    title: "JUNGLE ISLAND (Rom M Mix)"
+    path: "bgm_world1_romm.awb"
+    type: betting
+  - id: just_beyond_the_rainbow_soundcirclet_mix
+    title: "Just Beyond the Rainbow! (SoundCirclet Remix)"
+    path: "bgm_world1_rainbow.awb"
+    type: betting
+  - id: potassium_party
+    title: "Potassium Party"
+    path: "bgm_world1_kalium.awb"
+    type: betting
+  - id: volcanic_magma_breaks
+    title: "Volcanic Magma Breaks"
+    path: "bgm_world2.awb"
+    type: betting
+  - id: monkey_in_the_ocean
+    title: "Monkey in the Ocean"
+    path: "bgm_world3.awb"
+    type: betting
+  - id: whaaaale
+    title: "Whaaaale!"
+    path: "bgm_world4.awb"
+    type: betting
+  - id: roller_coaster_ride_smbmmm
+    title: "Roller Coaster Ride"
+    path: "bgm_world5_coaster.awb"
+    type: betting
+  - id: roller_coaster_ride_instrumental
+    title: "Roller Coaster Ride (Instrumental)"
+    path: "bgm_world5_inst.awb"
+    type: betting
+  - id: b_o_i_l_212_f_mix
+    title: "B.O.I.L. (212 F Mix)"
+    path: "bgm_world6.awb"
+    type: betting
+  - id: permanent_press
+    title: "Permanent Press"
+    path: "bgm_world7.awb"
+    type: betting
+  - id: clock_tower_raceway
+    title: "CLOCK TOWER RACEWAY"
+    path: "bgm_world8.awb"
+    type: betting
+  - id: its_too_good_to_be_true_ludosmo_remix
+    title: "Its Too Good To Be True (ludosmo remix)"
+    path: "bgm_world9_2gtbt.awb"
+    type: betting
+  - id: its_too_good_to_be_true_ludosmo_remix_instrumental
+    title: "Its Too Good To Be True (ludosmo remix) (Instrumental)"
+    path: "bgm_world9_2gtbti.awb"
+    type: betting
+  - id: you_are_now_in_the_space_quadrant_bad_future
+    title: "You Are Now In the Space Quadrant [Bad Future]"
+    path: "bgm_world9_bf.awb"
+    type: betting
+  - id: big_bad_monkey_ball
+    title: "Big Bad Monkey Ball"
+    path: "bgm_world10.awb"
+    type: betting
+  - id: bonus_stage_overamped_mix
+    title: "Bonus Stage (Overamped Mix)"
+    path: "bgm_bonus.awb"
+    type: betting
+  - id: monkeys_in_motion
+    title: "Monkeys in Motion"
+    path: "bgm_smb1_st1_mim.awb"
+    type: battle
+  - id: rolling_deep_in_the_thick_of_it
+    title: "Rolling Deep in the Thick of It"
+    path: "bgm_smb1_st1_thick.awb"
+    type: betting
+  - id: tidal_adventures_forever
+    title: "Tidal Adventures Forever"
+    path: "bgm_smb1_st2_taa.awb"
+    type: betting
+  - id: tidal_adventures_forever_instrumental
+    title: "Tidal Adventures Forever (Instrumental)"
+    path: "bgm_smb1_st2_taai.awb"
+    type: betting
+  - id: night_roll
+    title: "NIGHT ROLL"
+    path: "bgm_smb1_st3.awb"
+    type: battle
+  - id: sky_high_ape_mix
+    title: "Sky High (Ape Mix)"
+    path: "bgm_smb1_st4.awb"
+    type: battle
+  - id: zero_g_soda
+    title: "ZERO G SODA"
+    path: "bgm_smb1_st5.awb"
+    type: betting
+  - id: aladdin_s_rave
+    title: "ALADDIN'S RAVE"
+    path: "bgm_smb1_st6.awb"
+    type: betting
+  - id: snowball_effect
+    title: "Snowball Effect"
+    path: "bgm_smb1_st7.awb"
+    type: betting
+  - id: eye_wall
+    title: "Eye Wall"
+    path: "bgm_smb1_st8.awb"
+    type: battle
+  - id: master_stage_in_line_mix
+    title: "Master Stage (In-Line Mix)"
+    path: "bgm_smb1_stm.awb"
+    type: betting
+  - id: monkey_race_2_expert_intelligence_mix
+    title: "Monkey Race 2 Expert (Intelligence Mix)"
+    path: "bgm_pg_race.awb"
+    type: battle
+  - id: monkot_bingo
+    title: "Monkot Bingo"
+    path: "bgm_pg_fight.awb"
+    type: betting
+  - id: lo_fi_golfe_nova
+    title: "Lo-Fi Golfe Nova"
+    path: "bgm_pg_golf.awb"
+    type: break
+  - id: beyond_the_river
+    title: "Beyond the River"
+    path: "bgm_pg_boat.awb"
+    type: betting
+  - id: role_call_ball
+    title: "Role Call Ball"
+    path: "bgm_pg_bowling_rcb.awb"
+    type: betting
+  - id: we_do_a_little_bowling
+    title: "We Do a Little Bowling"
+    path: "bgm_pg_bowling_wdal.awb"
+    type: betting
+  - id: super_monkey_break
+    title: "!!! Super Monkey Break !!!"
+    path: "shot.txtp"
+    type: betting
+  - id: you_have_chosen_death_foolish_monkey
+    title: "You Have Chosen Death, Foolish Monkey"
+    path: "shotboss.txtp"
+    type: battle
+  - id: gorilla_warfare
+    title: "Gorilla Warfare"
+    path: "bgm_pg_dogfight.awb"
+    type: battle
+  - id: kick_it_smbmmm
+    title: "Kick It!"
+    path: "bgm_pg_futsal.awb"
+    type: betting
+  - id: bb
+    title: "bb"
+    path: "bgm_pg_baseball.awb"
+    type: betting
+  - id: love_love
+    title: "LOVE-LOVE"
+    path: "bgm_pg_tennis.awb"
+    type: betting
+  - id: wow_thx_for_playing
+    title: "WOW... thx for playing!!!"
+    path: "staffrool.awb"
+    type: betting
+...

--- a/Super Smash Bros. for Nintendo 3DS and Wii U/metadata.yaml
+++ b/Super Smash Bros. for Nintendo 3DS and Wii U/metadata.yaml
@@ -366,4 +366,8 @@ songs:
     title: "StreetSmash"
     path: "crs22_surechigaidairantou.lopus"
     type: warning
+  - id: donkey_kong_country_returns_vocals
+    title: "Donkey Kong Country Returns (Vocals)"
+    path: "Donkey Kong Country Returns (Vocals).brstm"
+    type: betting #everyone rise for the monke national anthem
 ...

--- a/Team Kirby Clash Deluxe/metadata.yaml
+++ b/Team Kirby Clash Deluxe/metadata.yaml
@@ -5,8 +5,8 @@ series: kirby
 platform: "3DS"
 year: 2017
 songs:
-  - id: decisive_battle_with_a_mighty_boss
-    title: "Decisive Battle with a Mighty Boss"
+  - id: a_decisive_battle_with_mighty_bosses
+    title: "A Decisive Battle With Mighty Bosses"
     path: "DynaDark.dspadpcm.bcstm"
     type: warning
   - id: grand_doomer_team_kirby_clash_deluxe

--- a/Totino's Mania/metadata.yaml
+++ b/Totino's Mania/metadata.yaml
@@ -1,0 +1,219 @@
+---
+id: totino_s_mania
+title: "Totino's Mania"
+series: sonic, siivagunner
+platform: "PC"
+is_fanwork: true 
+year: 2020
+#another Siivagunner mod, this time for Sonic Mania. Again, this is a mod so I'm saying it technically fits
+#and also I wanted rips of the punk pizza rolls
+songs: 
+  - id: get_stuffed_nachos
+    title: "GET STUFFED NACHOS"
+    path: "BlueSpheres.txtp"
+    type: betting
+  - id: star_dream_delusions
+    title: "Star Dream Delusions"
+    path: "BossEggman1.txtp"
+    type: battle
+  - id: eating_totinos_at_the_carnival_also_there_s_a_boss_or_whatever
+    title: "Eating Totinos At The Carnival... also there's a boss or whatever"
+    path: "BossEggman2.txtp"
+    type: battle
+  - id: punk_rock_pizza_illusions
+    title: "Punk Rock Pizza Illusions"
+    path: "BossFinal.txtp"
+    type: battle
+  - id: hi_temp_totino_go_hard_baked_roll_boss
+    title: "Hi-Temp Totino Go! - Hard-Baked Roll Boss"
+    path: "BossHBH.txtp"
+    type: betting
+  - id: diploma_dope_on_the_kitchen_floor_ft_ree_kid
+    title: "Diploma Dope on the Kitchen Floor (ft. Ree Kid)"
+    path: "BossMini.txtp"
+    type: warning
+  - id: dr_robotnik_lean_mean_pizza_roll_baking_machine
+    title: "Dr. Robotnik's Lean Mean Pizza Roll-Baking Machine"
+    path: "BossPuyo.txtp"
+    type: battle
+  - id: totinsnow_s_plant
+    title: "Totinsnow's Plant"
+    path: "ChemicalPlant1.txtp"
+    type: betting
+  - id: chemical_totino_s_of_mass_destruction
+    title: "Chemical Totino's of Mass Destruction"
+    path: "ChemicalPlant2.txtp"
+    type: betting
+  - id: baking_king
+    title: "BAKING KING"
+    path: "Competition.txtp"
+    type: result
+  - id: guided_tour_of_my_kitchen
+    title: "Guided Tour of My Kitchen"
+    path: "Credits.txtp"
+    type: result
+  - id: pizzeria_reveria
+    title: "Pizzeria Reveria"
+    path: "EggReverie.txtp"
+    type: battle
+  - id: you_have_been_initiated_you_are_now_part_of_the_totino_s_lifestyle
+    title: "You have been initiated. You are now part of the Totino's lifestyle."
+    path: "EggReveriePinch.txtp"
+    type: warning
+  - id: flying_pizzaroll_webzone
+    title: "Flying Pizzaroll Webzone"
+    path: "FlyingBattery1.txtp"
+    type: betting
+  - id: flying_bad_totinomance
+    title: "Flying Bad Totinomance"
+    path: "FlyingBattery2.txtp"
+    type: betting
+  - id: totino_hill_act_1
+    title: "Totino Hill Act 1"
+    path: "GreenHill1.txtp"
+    type: betting
+  - id: totino_hill_act_2
+    title: "Totino Hill Act 2"
+    path: "GreenHill2.txtp"
+    type: betting
+  - id: hard_boiled_pizza_roll_madness
+    title: "Hard-Boiled Pizza Roll Madness"
+    path: "HBHMischief.txtp"
+    type: warning
+  - id: oh_a_water_zone_i_cannot_wait_to_play_a_water_zone_it_s_the_least_amount_of_air_you_can_possibly_have_while_playing_sonic
+    title: "Oh, a water zone! I cannot wait to play a water zone. It's the least amount of air you can possibly have while playing Sonic"
+    path: "Hydrocity1.txtp"
+    type: betting
+  - id: nachocity_game
+    title: "Nachocity Game"
+    path: "Hydrocity2.txtp"
+    type: betting
+  - id: sonic_messin_with_invincibility
+    title: "Sonic Messin' With Invincibility"
+    path: "Invincible.txtp"
+    type: result
+  - id: these_totino_s_pizza_rolls_burned_my_mouth
+    title: "These Totino's Pizza Rolls Burned My Mouth"
+    path: "LavaReef1.txtp"
+    type: betting
+  - id: now_the_pizza_rolls_have_cooled_down_enough_for_me_to_eat
+    title: "Now the Pizza Rolls Have Cooled Down Enough for Me to Eat"
+    path: "LavaReef2.txtp"
+    type: betting
+  - id: comfort_zone_school_nachos_festival
+    title: "Comfort Zone - School Nachos Festival"
+    path: "MainMenu.txtp"
+    type: result
+  - id: whom_is_totinoboy8_for_totino_madness_act_1
+    title: "Whom Is TotinoBoy8? ...for Totino Madness, Act 1"
+    path: "MetallicMadness1.txtp"
+    type: betting
+  - id: metal_lick_for_totino_madness_act_2
+    title: "Metal Lick ...for Totino Madness, Act 2"
+    path: "MetallicMadness2.txtp"
+    type: betting
+  - id: vs_metal_totino_boy
+    title: "Vs. Metal Totino Boy"
+    path: "MetalSonic.txtp"
+    type: battle
+  - id: skyway_totinoctane
+    title: "Skyway Totinoctane"
+    path: "MirageSaloon1.txtp"
+    type: betting
+  - id: makistyle_pizzalero_for_totino_saloon
+    title: "Makistyle Pizzalero ...for Totino Saloon"
+    path: "MirageSaloon1K.txtp"
+    type: betting
+  - id: rolls_gallery
+    title: "Rolls Gallery"
+    path: "MirageSaloon2.txtp"
+    type: betting
+  - id: the_adventures_of_duance_and_totin0
+    title: "The Adventures of Duane and Totin0"
+    path: "OilOcean1.txtp"
+    type: betting 
+  - id: oil_onion_zone_act_2
+    title: "Oil Onion Zone Act 2"
+    path: "OilOcean2.txtp"
+    type: betting
+  - id: mario_steals_sonic_s_spotlight_while_playing_a_bonus_stage_and_munching_on_pizza_rolls_and_also_while_playing_a_3d_sonic_fangame_that_is_fucking_ridiculously_better_than_any_official_3d_sonic_game_or_at_least_the_ones_ive_played
+    title: "mario steals sonic's spotlight while playing a bonus stage and munching on pizza rolls and also while playing a 3d sonic fangame that is fucking ridiculously better than any official 3d sonic game or at least the ones ive played"
+    path: "Pinball.txtp"
+    type: betting
+  - id: scandal_is_sonic_part_of_the_totino_s_lifestyle
+    title: "SCANDAL! Is SONIC Part Of The TOTINO'S LIFESTYLE?!"
+    path: "PulpSolstice1.txtp"
+    type: betting
+  - id: pizza_blossom_halation_for_press_gangnam
+    title: "Pizza Blossom Halation ...for Press Gangnam"
+    path: "PulpSolstice2.txtp"
+    type: betting
+  - id: the_winner_of_a_lifetime_supply_of_pizza_rolls_totino_competition_results
+    title: "The Winner of a Lifetime Supply of Pizza Rolls (Totino Competition Results)"
+    path: "Results.txtp"
+    type: result
+  - id: love_live_sunshine_cassette_totino_select
+    title: "Love Live Sunshine Cassette - Totino Select"
+    path: "SaveSelect.txtp"
+    type: betting
+  - id: run_away_from_the_puzzle_room_very_fast
+    title: "run away from the puzzle room very fast"
+    path: "Sneakers.txtp"
+    type: warning
+  - id: comes_a_time_when_you_need_a_meal_quick_so_you_step_on_the_gas_and_head_towards_the_speedway
+    title: "Comes a time when you need a meal quick, so you step on the gas and head towards the speedway"
+    path: "StardustSpeedway1.txtp"
+    type: betting
+  - id: stardust_wisdom
+    title: "Stardust Wisdom"
+    path: "StardustSpeedway2.txtp"
+    type: betting
+  - id: lights_oven_microwave_for_totinopolis
+    title: "Lights, Oven, Microwave! ...for Totinopolis"
+    path: "Studiopolis1.txtp"
+    type: betting
+  - id: totinopolis_style
+    title: "Totinopolis Style"
+    path: "Studiopolis2.txtp"
+    type: betting
+  - id: sizzling_gift_zesty_transformation
+    title: "Sizzling Gift - Zesty Transformation"
+    path: "Super.txtp"
+    type: warning
+  - id: built_to_rule_vocal_version
+    title: "Built to Rule - Vocal Version"
+    path: "TitanicMonarch1.txtp"
+    type: betting
+  - id: totinic_monarch
+    title: "Totinic Monarch"
+    path: "TitanicMonarch2.txtp"
+    type: betting
+  - id: totino_horizon_and_maki_ending
+    title: "Totino Horizon (& Maki Ending)"
+    path: "TrueEnd.txtp"
+    type: result
+  - id: special_everyday_bro
+    title: "Special Everyday Bro"
+    path: "UFOSpecial.txtp"
+    type: betting
+  - id: under_the_sea_that_s_under_pizza_island
+    title: "Under the Sea (That's Under Pizza Island)"
+    path: "AngelIsland2.txtp"
+    ends: 1:09
+    type: betting
+  - id: double_bake_encore_stage_select
+    title: "Double Bake (Encore Stage Select)"
+    path: "EncoreMenu.txtp"
+    ends: 1:04
+    type: betting
+  - id: we_are_pizza_totino_s_friends
+    title: "We Are Pizza Totino's Friends"
+    path: "IntroHP.txtp"
+    ends: 1:17
+    type: betting
+  - id: rolls_of_the_high_quality_icons
+    title: "Rolls of the High Quality Icons"
+    path: "IntroTee.txtp"
+    ends: 1:18
+    type: betting
+...

--- a/Toy Story 2 Woody Sousaku Daisakusen!!/metadata.yaml
+++ b/Toy Story 2 Woody Sousaku Daisakusen!!/metadata.yaml
@@ -41,15 +41,15 @@ songs:
     path: "20 Defeat.vgz"
     type: result
   - id: unknown_1_ts2p
-    title: "Unknown 1.vgz"
+    title: "Unknown 1"
     path: "21 Unknown 1.vgz"
     type: warning
   - id: unknown_2_ts2p
-    title: "Unknown 2.vgz"
+    title: "Unknown 2"
     path: "22 Unknown 2.vgz"
     type: result
   - id: unknown_3_ts2p
-    title: "Unknown 3.vgz"
+    title: "Unknown 3"
     path: "23 Unknown 3.vgz"
     type: result
 ...

--- a/Undertale Yellow/metadata.yaml
+++ b/Undertale Yellow/metadata.yaml
@@ -389,10 +389,10 @@ songs:
     title: "subconscious"
     path: "mus_the_wandering.txtp"
     type: warning
-  - id: snow_yellow
-    title: "snow"
-    path: "mus_snow.txtp"
-    type: break
+  # - id: snow_yellow
+    # title: "snow"
+    # path: "mus_snow.txtp"
+    # type: break
   - id: gotcha_wink_emoticon
     title: "gotcha ;)"
     path: "mus_gotcha.txtp"

--- a/Vampire Survivors/metadata.yaml
+++ b/Vampire Survivors/metadata.yaml
@@ -1,0 +1,63 @@
+---
+id: vampire_survivors
+title: "Vampire Survivors"
+platform: "Various"
+year: 2022
+songs:
+  - id: legacy_of_the_moonspell
+    title: "Legacy of the Moonspell"
+    path: "Legacy of the Moonspell.brstm"
+    type: battle
+  - id: rumble_kachara
+    title: "Rumble Kachara"
+    path: "Rumble Kachara.brstm"
+    type: battle
+  - id: slaying_dragons
+    title: "Slaying Dragons"
+    path: "Slaying Dragons.brstm"
+    type: battle
+  - id: red_and_blue
+    title: "Red & Blue"
+    path: "Red & Blue.brstm"
+    type: battle
+  - id: gaze_up_at_the_stars
+    title: "Gaze Up at the Stars"
+    path: "Gaze Up at the Stars.brstm"
+    type: battle
+  - id: mighty_illusion
+    title: "Mighty Illusion"
+    path: "Mighty Illusion.brstm"
+    type: battle
+  - id: crystal_allure
+    title: "Crystal Allure"
+    path: "Crystal Allure.brstm"
+    type: betting
+  - id: barely_staying_alive
+    title: "Barely Staying Alive"
+    path: "Barely Staying Alive.brstm"
+    type: betting
+  - id: reincarnated_echoes
+    title: "Reincarnated Echoes"
+    path: "Reincarnated Echoes.brstm"
+    type: betting
+  - id: hide_and_survive
+    title: "Hide and Survive"
+    path: "Hide and Survive.brstm"
+    type: battle
+  - id: i_m_every_reaper
+    title: "I'm Every Reaper"
+    path: "I'm Every Reaper.brstm"
+    type: battle
+  - id: libro_inferno
+    title: "Libro Inferno"
+    path: "Libro Inferno.brstm"
+    type: battle
+  - id: forest_night_fever
+    title: "Forest Night Fever"
+    path: "Forest Night Fever.brstm"
+    type: betting
+  - id: emergency_meeting_vs
+    title: "Emergency Meeting"
+    path: "Emergency Meeting (Custom loop).brstm"
+    type: battle
+...


### PR DESCRIPTION
Update 80 according to M4, anyway. I didn't think I would have much to add since the last update, but here we are.

The notables:

- Some metadata changes, requested from the TPP team. Basically removal of some ambient tracks and some name changes for Kirby songs.
- Beta Pokemon music! Thanks to whoever on Smash Custom Music made these - I couldn't really crack it on my own
- NHL 96 and Biometal. Did these when I realized that 2Unlimited helped with the soundtracks for both. I had to rip NHL manually. 
- SiIvaGunner tracks! I looked through their archives and added pretty much every track which they released through a fangame or mod. I always wanted to add more SG tracks, but never really had the chance - either they were rejected or I didn't have the technical knowhow to add them in. But given I don't know the future of TPP music, might as well add it anyway and remove any tracks y'all don't like. Also grand dad funne
- The Pokemon Masters tracks, as per usual. It's been harder to find datarips, with many of them being like a month, so don't be surprised if it takes longer for me to get the new songs. 

Dunno what else to say here. Trying my best to add more music, but it's not easy - especially in this environment. Don't know how longer I will do this for, but thanks for believing in me however far we go.